### PR TITLE
Fixed extension in XmlSerializer codec to 'xml'

### DIFF
--- a/src/OpenRasta/Codecs/application/xml/XmlSerializerCodec.cs
+++ b/src/OpenRasta/Codecs/application/xml/XmlSerializerCodec.cs
@@ -15,7 +15,7 @@ using OpenRasta.Web;
 
 namespace OpenRasta.Codecs
 {
-    [MediaType("application/xml;q=0.4", ".xml")]
+    [MediaType("application/xml;q=0.4", "xml")]
     public class XmlSerializerCodec : XmlCodec
     {
         public override object ReadFrom(IHttpEntity request, IType destinationType, string parameterName)


### PR DESCRIPTION
As posted on the google group, found bug with the string passed to the extension parameter of MediaTypeAttribute by the XmlSerializerCodec which was causing ContentTypeExtensionUriDecorator when added to the resource space, not use the XmlSerializerCodec with a uri extension of .xml
