### PR TITLE
Response Content-Type header no longer contains the quality qualifier.

### DIFF
--- a/src/OpenRasta/Hosting/HttpListener/HttpListenerResponse.cs
+++ b/src/OpenRasta/Hosting/HttpListener/HttpListenerResponse.cs
@@ -38,7 +38,7 @@ namespace OpenRasta.Hosting.HttpListener
             if (HeadersSent)
                 throw new InvalidOperationException("The headers have already been sent.");
             _nativeResponse.Headers.Clear();
-            foreach (var header in Headers.Where(h => h.Key != "Content-Length"))
+            foreach (var header in Headers.Where(h => h.Key != "Content-Length" && h.Key != "Content-Type"))
             {
                 try
                 {
@@ -52,6 +52,11 @@ namespace OpenRasta.Hosting.HttpListener
             }
             HeadersSent = true;
             _nativeResponse.ContentLength64 = Headers.ContentLength.GetValueOrDefault();
+
+            if (Headers.ContentType != null)
+            {
+                _nativeResponse.ContentType = Headers.ContentType.MediaType;
+            }
             // TODO: Enable streaming straight back to native response output sting
 
 


### PR DESCRIPTION
Fixed https://github.com/openrasta/openrasta-core/issues/13 for the HttpListener host.
