### PR TITLE
HttpListenerHost: Dispose the HttpListener field when disposing HttpListenerHost class

### DIFF
--- a/src/OpenRasta/Codecs/text/plain/TextPlainCodec.cs
+++ b/src/OpenRasta/Codecs/text/plain/TextPlainCodec.cs
@@ -35,7 +35,11 @@ namespace OpenRasta.Codecs
             {
                 var encoding = DetectTextEncoding(request);
 
-                string result = new StreamReader(request.Stream, encoding).ReadToEnd();
+                string result;
+                using (var sr = new StreamReader(request.Stream, encoding))
+                {
+                    result = sr.ReadToEnd();
+                }
                 _values.Add(request, result);
             }
             return _values[request];

--- a/src/OpenRasta/Hosting/HttpListener/HttpListenerHost.cs
+++ b/src/OpenRasta/Hosting/HttpListener/HttpListenerHost.cs
@@ -142,6 +142,7 @@ namespace OpenRasta.Hosting.HttpListener
                     HostManager.UnregisterHost(this);
                 }
                 _listener.Abort();
+                ((IDisposable)_listener).Dispose();
                 _isDisposed = true;
             }
         }

--- a/src/OpenRasta/Hosting/HttpListener/HttpListenerResponse.cs
+++ b/src/OpenRasta/Hosting/HttpListener/HttpListenerResponse.cs
@@ -6,7 +6,7 @@ using OpenRasta.Web;
 
 namespace OpenRasta.Hosting.HttpListener
 {
-    public class HttpListenerResponse : IResponse
+    public class HttpListenerResponse : IResponse, IDisposable
     {
         readonly HttpListenerCommunicationContext _context;
         readonly System.Net.HttpListenerResponse _nativeResponse;
@@ -65,6 +65,13 @@ namespace OpenRasta.Hosting.HttpListener
                 if (_context != null)
                     _context.ServerErrors.Add(new Error { Message = ex.ToString() });
             }
+        }
+
+
+        public void Dispose()
+        {
+            _tempStream.Dispose();
+            ((IDisposable)_nativeResponse).Dispose();
         }
     }
 }

--- a/src/OpenRasta/IO/BoundaryStreamReader.cs
+++ b/src/OpenRasta/IO/BoundaryStreamReader.cs
@@ -16,7 +16,7 @@ using OpenRasta.IO.Diagnostics;
 
 namespace OpenRasta.IO
 {
-    public class BoundaryStreamReader
+    public class BoundaryStreamReader : IDisposable
     {
         readonly byte[] _beginBoundary;
         readonly string _beginBoundaryAsString;
@@ -415,6 +415,11 @@ namespace OpenRasta.IO
             {
                 throw new NotSupportedException();
             }
+        }
+
+        public void Dispose()
+        {
+            _previousStream.Dispose();
         }
     }
 }

--- a/src/OpenRasta/IO/BoundaryStreamReader.cs
+++ b/src/OpenRasta/IO/BoundaryStreamReader.cs
@@ -126,11 +126,13 @@ namespace OpenRasta.IO
         {
             if (AtEndBoundary)
                 return new byte[0];
-            var part = new MemoryStream();
-            long count = ReadNextPart(part, true);
-            var result = new byte[count];
-            Buffer.BlockCopy(part.GetBuffer(), 0, result, 0, (int)count);
-            return result;
+            using (var part = new MemoryStream())
+            {
+                long count = ReadNextPart(part, true);
+                var result = new byte[count];
+                Buffer.BlockCopy(part.GetBuffer(), 0, result, 0, (int)count);
+                return result;
+            }
         }
 
         public long ReadNextPart(Stream destinationStream, bool continueToNextBoundaryOnEmptyRead)

--- a/src/OpenRasta/IO/IFile.cs
+++ b/src/OpenRasta/IO/IFile.cs
@@ -38,7 +38,7 @@ namespace OpenRasta.IO
         Save
     }
 #pragma warning disable 0618
-    public class InMemoryFile : IFile, IReceivedFile
+    public class InMemoryFile : IFile, IReceivedFile, IDisposable
     {
         public InMemoryFile() : this(new MemoryStream())
         {
@@ -63,6 +63,11 @@ namespace OpenRasta.IO
         string IReceivedFile.OriginalName
         {
             get { return FileName; }
+        }
+
+        public void Dispose()
+        {
+            _stream.Dispose();
         }
     }
 #pragma warning restore 0618

--- a/src/OpenRasta/Web/HttpEntity.cs
+++ b/src/OpenRasta/Web/HttpEntity.cs
@@ -16,7 +16,7 @@ using OpenRasta.IO;
 
 namespace OpenRasta.Web
 {
-    public class HttpEntity : IHttpEntity
+    public class HttpEntity : IHttpEntity, IDisposable
     {
         public HttpEntity(HttpHeaderDictionary messageheaders, Stream entityBodyStream)
         {
@@ -52,6 +52,11 @@ namespace OpenRasta.Web
 
         public Stream Stream { get; private set; }
         public IList<Error> Errors { get; set; }
+
+        public void Dispose()
+        {
+            Stream.Dispose();
+        }
     }
 }
 

--- a/src/OpenRasta/Web/Markup/Elements/Element.cs
+++ b/src/OpenRasta/Web/Markup/Elements/Element.cs
@@ -58,10 +58,11 @@ namespace OpenRasta.Web.Markup.Elements
             get
             {
                 var sb = new StringBuilder();
-                var sw = new StringWriter(sb);
-                var writer = new XhtmlTextWriter(sw);
-                new XhtmlNodeWriter().Write(writer, this);
-                return sb.ToString();
+                using (var sw = new StringWriter(sb)) {
+                    var writer = new XhtmlTextWriter(sw);
+                    new XhtmlNodeWriter().Write(writer, this);
+                    return sb.ToString();
+                }
             }
         }
         public override string ToString()


### PR DESCRIPTION
Make sure Dispose() disposes all IDisposable fields in this class (Abort() may already do it, but it's safer to make sure to do it this way).