### PR TITLE
CreateUri formats the query parameters with ";" instead of "&"

### DIFF
--- a/src/OpenRasta/UriTemplate.cs
+++ b/src/OpenRasta/UriTemplate.cs
@@ -160,7 +160,7 @@ namespace OpenRasta
                 path.Append('?');
                 foreach (var querySegment in _queryStringVariables)
                 {
-                    path.Append(querySegment.Value.Key).Append("=").Append(parameters[querySegment.Value.Value]).Append(";");
+                    path.Append(querySegment.Value.Key).Append("=").Append(parameters[querySegment.Value.Value]).Append("&");
                 }
                 path.Remove(path.Length - 1, 1);
             }


### PR DESCRIPTION
Hi,

When using the CreateUri extension method, the generated URI has its query string parameters separated by semi-colons ";" instead of ampersands "&".

The problem seems to be in BinByName in [UriTemplate.cs](https://github.com/openrasta/openrasta-core/blob/2.1/src/OpenRasta/UriTemplate.cs) line 163 :

```
path.Append(querySegment.Value.Key).Append("=").Append(parameters[querySegment.Value.Value]).Append(";");
```

I changed ";" to "&".
Is it the right thing to do?

Thanks
