### PR TITLE
Fix for "OpenRasta DI PerRequest lifetime problem"

### DIFF
--- a/src/OpenRasta/DI/Internal/DependencyRegistrationCollection.cs
+++ b/src/OpenRasta/DI/Internal/DependencyRegistrationCollection.cs
@@ -51,7 +51,7 @@ namespace OpenRasta.DI.Internal
             {
                 foreach (var reg in _registrations)
                 {
-                    var toRemove = reg.Value.Where(x => x.Key == key).ToList();
+                    var toRemove = reg.Value.Where(x => x.IsInstanceRegistration && x.Key == key).ToList();
 
                     toRemove.ForEach(x => reg.Value.Remove(x));
                 }


### PR DESCRIPTION
This fixes OpenRasta's (long-standing: http://stackoverflow.com/questions/5163606) inability to handle `DependencyLifetime.PerRequest` **non-Instance** registrations properly.
