### PR TITLE
Race condition disposing HttpListenerHost and checking disposed

### DIFF
--- a/src/OpenRasta/Hosting/HttpListener/HttpListenerHost.cs
+++ b/src/OpenRasta/Hosting/HttpListener/HttpListenerHost.cs
@@ -74,6 +74,11 @@ namespace OpenRasta.Hosting.HttpListener
             {
                 return;
             }
+            catch (ObjectDisposedException)
+            {
+                return;
+            }
+
             QueueNextRequestPending();
             var ambientContext = new AmbientContext();
             var context = new HttpListenerCommunicationContext(this, nativeContext);


### PR DESCRIPTION
If you keep starting and stopping an httpListenerHost within the same process (as I do in my tests) you will hit this error, because when we process a request we check if we are already disposed but if the object is disposed in between then and getting the context we will get an ObjectDisposedException
