### PR TITLE
Return 400 BadRequest if accept hader is malformed and can't be parsed

### DIFF
--- a/src/OpenRasta.Tests.Unit/Pipeline/Contributors/ResponseEntityCodecResolver_Specification.cs
+++ b/src/OpenRasta.Tests.Unit/Pipeline/Contributors/ResponseEntityCodecResolver_Specification.cs
@@ -72,7 +72,7 @@ namespace ResponseEntityCodecResolver_Specification
         }
 
         [Test]
-        public void an_error_is_returned_when_the_accept_header_is_malformed()
+        public void bad_request_is_returned_when_the_accept_header_has_only_one_entry_that_is_invalid()
         {
             given_pipeline_contributor<ResponseEntityCodecResolverContributor>();
             given_response_entity(new Customer());
@@ -83,6 +83,20 @@ namespace ResponseEntityCodecResolver_Specification
             
             Context.OperationResult.ShouldBeOfType<OperationResult.BadRequest>();
             Context.Response.Headers["Warning"].ShouldBe("199 Malformed accept header");
+        }
+
+        [Test]
+        public void ignore_an_invalid_entry_if_accept_header_has_mixture_of_valid_and_invalid_values()
+        {
+            given_pipeline_contributor<ResponseEntityCodecResolverContributor>();
+            given_response_entity(new Customer());
+            given_registration_codec<CustomerCodec, Customer>("text/plain");
+            given_request_header_accept("text/plain,q=");
+
+            when_running_pipeline();
+
+            Context.PipelineData.ResponseCodec.CodecType.ShouldBe<CustomerCodec>();
+            Context.Response.Entity.ContentType.MediaType.ShouldBe("text/plain");
         }
 
         [Test]

--- a/src/OpenRasta.Tests.Unit/Pipeline/Contributors/ResponseEntityCodecResolver_Specification.cs
+++ b/src/OpenRasta.Tests.Unit/Pipeline/Contributors/ResponseEntityCodecResolver_Specification.cs
@@ -72,6 +72,20 @@ namespace ResponseEntityCodecResolver_Specification
         }
 
         [Test]
+        public void an_error_is_returned_when_the_accept_header_is_malformed()
+        {
+            given_pipeline_contributor<ResponseEntityCodecResolverContributor>();
+            given_response_entity(new Customer());
+            given_registration_codec<CustomerCodec, Customer>("text/plain");
+            given_request_header_accept("q=");
+
+            when_sending_notification<KnownStages.IOperationResultInvocation>().ShouldBe(PipelineContinuation.RenderNow);
+            
+            Context.OperationResult.ShouldBeOfType<OperationResult.BadRequest>();
+            Context.Response.Headers["Warning"].ShouldBe("199 Malformed accept header");
+        }
+
+        [Test]
         public void an_error_is_returned_when_no_suitable_codec_is_found()
         {
             given_pipeline_contributor<ResponseEntityCodecResolverContributor>();

--- a/src/OpenRasta/OpenRasta.csproj
+++ b/src/OpenRasta/OpenRasta.csproj
@@ -30,6 +30,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/OpenRasta/Pipeline/Contributors/ResponseEntityCodecResolverContributor.cs
+++ b/src/OpenRasta/Pipeline/Contributors/ResponseEntityCodecResolverContributor.cs
@@ -46,13 +46,11 @@ namespace OpenRasta.Pipeline.Contributors
 
 
             var responseEntityType = _typeSystem.FromInstance(context.Response.Entity.Instance);
-            IEnumerable<CodecRegistration> sortedCodecs;
+            IEnumerable<MediaType> acceptedContentTypes;
             
             try
             {
-                var acceptedContentTypes = MediaType.Parse(string.IsNullOrEmpty(acceptHeader) ? "*/*" : acceptHeader);
-                sortedCodecs = _codecs.FindMediaTypeWriter(responseEntityType, acceptedContentTypes);
-
+                acceptedContentTypes = MediaType.Parse(string.IsNullOrEmpty(acceptHeader) ? "*/*" : acceptHeader);
             }
             catch (FormatException)
             {
@@ -63,7 +61,7 @@ namespace OpenRasta.Pipeline.Contributors
                 return PipelineContinuation.RenderNow;
             }
 
-
+            var sortedCodecs = _codecs.FindMediaTypeWriter(responseEntityType, acceptedContentTypes);
             int codecsCount = sortedCodecs.Count();
             var negotiatedCodec = sortedCodecs.FirstOrDefault();
 

--- a/src/OpenRasta/Pipeline/Contributors/ResponseEntityCodecResolverContributor.cs
+++ b/src/OpenRasta/Pipeline/Contributors/ResponseEntityCodecResolverContributor.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRasta.Codecs;
@@ -43,14 +44,28 @@ namespace OpenRasta.Pipeline.Contributors
 
             string acceptHeader = context.Request.Headers[HEADER_ACCEPT];
 
-            IEnumerable<MediaType> acceptedContentTypes =
-                MediaType.Parse(string.IsNullOrEmpty(acceptHeader) ? "*/*" : acceptHeader);
-            IType responseEntityType = _typeSystem.FromInstance(context.Response.Entity.Instance);
 
-            IEnumerable<CodecRegistration> sortedCodecs = _codecs.FindMediaTypeWriter(responseEntityType,
-                                                                                      acceptedContentTypes);
+            var responseEntityType = _typeSystem.FromInstance(context.Response.Entity.Instance);
+            IEnumerable<CodecRegistration> sortedCodecs;
+            
+            try
+            {
+                var acceptedContentTypes = MediaType.Parse(string.IsNullOrEmpty(acceptHeader) ? "*/*" : acceptHeader);
+                sortedCodecs = _codecs.FindMediaTypeWriter(responseEntityType, acceptedContentTypes);
+
+            }
+            catch (FormatException)
+            {
+                Log.WriteWarning("Accept header: {0} is malformed", acceptHeader);
+
+                context.Response.Headers["Warning"] = "199 Malformed accept header";
+                context.OperationResult = new OperationResult.BadRequest();
+                return PipelineContinuation.RenderNow;
+            }
+
+
             int codecsCount = sortedCodecs.Count();
-            CodecRegistration negotiatedCodec = sortedCodecs.FirstOrDefault();
+            var negotiatedCodec = sortedCodecs.FirstOrDefault();
 
             if (negotiatedCodec != null)
             {

--- a/src/OpenRasta/Web/MediaType.cs
+++ b/src/OpenRasta/Web/MediaType.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Net.Mime;
@@ -214,10 +215,24 @@ namespace OpenRasta.Web
             if (contentTypeList == null)
                 return new List<MediaType>();
 
-            return from mediaTypeComponent in contentTypeList.Split(',')
-                   let mediatype = new MediaType(mediaTypeComponent.Trim())
-                   orderby mediatype descending
-                   select mediatype;
+            var contentTypes = contentTypeList.Split(',');
+            var mediaTypes = new List<MediaType>();
+            foreach (var contentType in contentTypes)
+            {
+                try
+                {
+                    mediaTypes.Add(new MediaType(contentType.Trim()));
+                }
+                catch (FormatException)
+                {
+                    bool isThisOnlyContentTypeAndMalformed = contentTypes.Count() == 1;
+                    if (isThisOnlyContentTypeAndMalformed) throw;
+                }
+            }
+
+            
+
+            return mediaTypes.OrderByDescending(m => m.MediaType);
         }
 
         public class MediaTypeEqualityComparer : IEqualityComparer<MediaType>

--- a/src/OpenRasta/Web/MediaType.cs
+++ b/src/OpenRasta/Web/MediaType.cs
@@ -232,7 +232,7 @@ namespace OpenRasta.Web
 
             
 
-            return mediaTypes.OrderByDescending(m => m.MediaType);
+            return mediaTypes.OrderByDescending(m => m);
         }
 
         public class MediaTypeEqualityComparer : IEqualityComparer<MediaType>


### PR DESCRIPTION
At Huddle, we had several occurrences that the server receive requests with malformed accept header. MediaType cannot parse the header and throws FormatException, which causes the server to return 500 InternalServerError, writing error logs. After some discussion, our consensus is that OpenRasta logs warning and return 400 BadRequest

* Used try, catch in parsing and find media types from Accept header.
* Return 400 BadRequest and Render now.
* Added a unit test