### PR TITLE
Add 202 Accepted operation result subclass

### DIFF
--- a/src/OpenRasta/Web/OperationResult.cs
+++ b/src/OpenRasta/Web/OperationResult.cs
@@ -193,8 +193,7 @@ namespace OpenRasta.Web
         /// </summary>
         public class Accepted : OperationResult
         {
-            public Accepted()
-                : base(202)
+            public Accepted() : base(202)
             {
             }
         }


### PR DESCRIPTION
At Huddle we've been using `OperationResult.OK` and then altering the status code to 202 in order to return Accepted responses. 

I hoping this makes that code a bit clearer.
