### PR TITLE
binding to an invalid guid will no longer 500

### DIFF
--- a/src/OpenRasta.Testing/Contexts/media_type_reader_context.cs
+++ b/src/OpenRasta.Testing/Contexts/media_type_reader_context.cs
@@ -67,6 +67,11 @@ namespace OpenRasta.Testing.Contexts
             return (T)_theResult;
         }
 
+        protected void then_decoding_result_is_missing()
+        {
+            _theResult.ShouldBe(Missing.Value);
+        }
+
         protected void when_decoding<T>()
         {
             when_decoding<T>("entity");

--- a/src/OpenRasta.Tests.Unit/Codecs/ApplicationXWwwUrlformEncodedCodec_Specification.cs
+++ b/src/OpenRasta.Tests.Unit/Codecs/ApplicationXWwwUrlformEncodedCodec_Specification.cs
@@ -78,6 +78,30 @@ namespace ApplicationXWwwUrlformEncodedCodec_Specification
             then_decoding_result<string>()
                 .ShouldBe("John");
         }
+
+        [Test]
+        public void guids_are_assigned()
+        {
+            given_context();
+            given_request_stream("myguid=044A624B-466A-4383-89FA-A02B629C78B9");
+
+            when_decoding<Guid>("myguid");
+
+            then_decoding_result<Guid>()
+                .ShouldBe(new Guid("044A624B-466A-4383-89FA-A02B629C78B9"));
+        }
+
+        [Test]
+        public void invalid_guids_are_assigned()
+        {
+            given_context();
+            given_request_stream("myguid=xxx");
+
+            when_decoding<Guid>("myguid");
+
+            then_decoding_result_is_missing();
+        }
+
         [Test]
         public void integers_are_assigned()
         {

--- a/src/OpenRasta/TypeSystem/ReflectionBased/ReflectionExtensions.cs
+++ b/src/OpenRasta/TypeSystem/ReflectionBased/ReflectionExtensions.cs
@@ -436,6 +436,17 @@ namespace OpenRasta.TypeSystem.ReflectionBased
                 }
             }
 
+            if (type == typeof(Guid))
+            {
+                Guid validGuid;
+                if (!Guid.TryParse(propertyValue, out validGuid))
+                {
+                    throw new NotSupportedException(propertyValue + " is not a valid Guid"); 
+                }
+
+                return validGuid;
+            }
+
             recursionDefender = recursionDefender ?? new Stack<Type>();
             foreach (var constructor in type.GetConstructors())
             {
@@ -462,7 +473,7 @@ namespace OpenRasta.TypeSystem.ReflectionBased
                 {
                     try
                     {
-                      return constructor.Invoke( new[] { value });
+                        return constructor.Invoke( new[] { value });
                     }
                     catch (Exception ex)
                     {

--- a/src/OpenRasta/TypeSystem/ReflectionBased/ReflectionExtensions.cs
+++ b/src/OpenRasta/TypeSystem/ReflectionBased/ReflectionExtensions.cs
@@ -425,6 +425,17 @@ namespace OpenRasta.TypeSystem.ReflectionBased
                 }
             }
 
+            if (type == typeof(Guid))
+            {
+                Guid validGuid;
+                if (!Guid.TryParse(propertyValue, out validGuid))
+                {
+                    return null;
+                }
+
+                return validGuid;
+            }
+
             if (type.IsPrimitive)
             {
                 try
@@ -434,17 +445,6 @@ namespace OpenRasta.TypeSystem.ReflectionBased
                 catch
                 {
                 }
-            }
-
-            if (type == typeof(Guid))
-            {
-                Guid validGuid;
-                if (!Guid.TryParse(propertyValue, out validGuid))
-                {
-                    throw new NotSupportedException(propertyValue + " is not a valid Guid"); 
-                }
-
-                return validGuid;
             }
 
             recursionDefender = recursionDefender ?? new Stack<Type>();

--- a/src/OpenRasta/TypeSystem/ReflectionBased/ReflectionExtensions.cs
+++ b/src/OpenRasta/TypeSystem/ReflectionBased/ReflectionExtensions.cs
@@ -470,16 +470,7 @@ namespace OpenRasta.TypeSystem.ReflectionBased
                 }
 
                 if (value != null)
-                {
-                    try
-                    {
-                        return constructor.Invoke( new[] { value });
-                    }
-                    catch (Exception ex)
-                    {
-                        throw new NotSupportedException("Unable to construct type with given value", ex);
-                    }
-                }
+                    return constructor.Invoke(new[] { value });
             }
 
 #if !SILVERLIGHT

--- a/src/OpenRasta/TypeSystem/ReflectionBased/ReflectionExtensions.cs
+++ b/src/OpenRasta/TypeSystem/ReflectionBased/ReflectionExtensions.cs
@@ -459,7 +459,16 @@ namespace OpenRasta.TypeSystem.ReflectionBased
                 }
 
                 if (value != null)
-                    return constructor.Invoke(new[] { value });
+                {
+                    try
+                    {
+                      return constructor.Invoke( new[] { value });
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new NotSupportedException("Unable to construct type with given value", ex);
+                    }
+                }
             }
 
 #if !SILVERLIGHT


### PR DESCRIPTION
When making a `POST` call to OpenRasta with a form body containing an invalid Guid we are getting 500 internal server errors in the response.

### Fix

To fix the issue I have altered the `ReflectionExtensions.cs` so that when it invokes the constructor of a given type it is wrapped in a try catch block so any exceptions are caught and returned as a `NotSupportedException` and will be treated as normal.

### Reproduction

* Create a POST handler with a View containing a Guid property
* Make a POST call with form data
* Supply form with an invalid guid for the property

### Actual Result

* 500 Internal Server Error

Logged Exeption ...

```
Step into: Stepping over non-user code 'OpenRasta.Pipeline.PipelineRunner.ExecuteContributor'
            11-[2015-01-30 09:56:49Z] Error(0) An error of type System.Reflection.TargetInvocationException has been thrown
            11-[2015-01-30 09:56:49Z] Error(0) System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.FormatException: Guid should contain 32 digits with 4 dashes (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx).
            11-[2015-01-30 09:56:49Z] Error(0)    at System.Guid.GuidResult.SetFailure(ParseFailureKind failure, String failureMessageID, Object failureMessageFormatArgument, String failureArgumentName, Exception innerException)
            11-[2015-01-30 09:56:49Z] Error(0)    at System.Guid.TryParseGuidWithNoStyle(String guidString, GuidResult& result)
            11-[2015-01-30 09:56:49Z] Error(0)    at System.Guid.TryParseGuid(String g, GuidStyles flags, GuidResult& result)
            11-[2015-01-30 09:56:49Z] Error(0)    at System.Guid..ctor(String g)
            11-[2015-01-30 09:56:49Z] Error(0)    --- End of inner exception stack trace ---
            11-[2015-01-30 09:56:49Z] Error(0)    at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)
            11-[2015-01-30 09:56:49Z] Error(0)    at System.Reflection.RuntimeConstructorInfo.Invoke(BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
            11-[2015-01-30 09:56:49Z] Error(0)    at OpenRasta.TypeSystem.ReflectionBased.ReflectionExtensions.CreateInstanceFromString(Type type, String propertyValue, Stack`1 recursionDefender)
            11-[2015-01-30 09:56:49Z] Error(0)    at OpenRasta.Codecs.AbstractApplicationXWwwFormUrlencodedCodec.ConvertValuesByString(String strings, Type entityType)
            11-[2015-01-30 09:56:49Z] Error(0)    at OpenRasta.TypeSystem.ReflectionBased.ReflectionExtensions.CreateInstanceFrom[T](Type type, IEnumerable`1 propertyValues, ValueConverter`1 converter)
            11-[2015-01-30 09:56:49Z] Error(0)    at OpenRasta.TypeSystem.ReflectionBased.ReflectionBasedType.TryCreateInstance[T](IEnumerable`1 values, ValueConverter`1 converter, Object& result)
            11-[2015-01-30 09:56:49Z] Error(0)    at OpenRasta.TypeSystem.PropertyBuilder.TrySetValue[T](IEnumerable`1 values, ValueConverter`1 converter)
            11-[2015-01-30 09:56:49Z] Error(0)    at OpenRasta.Binding.KeyedValuesBinder.SetProperty[TValue](String key, IEnumerable`1 values, ValueConverter`1 converter)
            11-[2015-01-30 09:56:49Z] Error(0)    at OpenRasta.Binding.KeyedValues`1.SetProperty(IObjectBinder binder)
            11-[2015-01-30 09:56:49Z] Error(0)    at System.Linq.Enumerable.WhereEnumerableIterator`1.MoveNext()
            11-[2015-01-30 09:56:49Z] Error(0)    at OpenRasta.Collections.ObservableIterator`1.<GetEnumerator>d__0.MoveNext()
            11-[2015-01-30 09:56:49Z] Error(0)    at System.Linq.Enumerable.Count[TSource](IEnumerable`1 source)
            11-[2015-01-30 09:56:49Z] Error(0)    at OpenRasta.Codecs.CodecExtensions.<>c__DisplayClassb.<TryAssignKeyValues>b__a(Boolean result, IObjectBinder binder)
            11-[2015-01-30 09:56:49Z] Error(0)    at System.Linq.Enumerable.Aggregate[TSource,TAccumulate](IEnumerable`1 source, TAccumulate seed, Func`3 func)
            11-[2015-01-30 09:56:49Z] Error(0)    at OpenRasta.OperationModel.Hydrators.RequestEntityReaderHydrator.<Process>d__8.MoveNext()
            11-[2015-01-30 09:56:49Z] Error(0)    at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
            11-[2015-01-30 09:56:49Z] Error(0)    at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
            11-[2015-01-30 09:56:49Z] Error(0)    at OpenRasta.Pipeline.Contributors.AbstractOperationProcessing`2.ProcessOperations(ICommunicationContext context)
            11-[2015-01-30 09:56:49Z] Error(0)    at OpenRasta.Pipeline.PipelineRunner.ExecuteContributor(ICommunicationContext context, ContributorCall call)
        11-[2015-01-30 09:56:49Z] Stop(1) Exiting PipelineRunner
```

### Expected Result

* Should return a 4xx Status not 500