### PR TITLE
updating so now the form codec will not 500 when dealing with nullable guids

### DIFF
--- a/src/OpenRasta.Tests.Unit/Codecs/ApplicationXWwwUrlformEncodedCodec_Specification.cs
+++ b/src/OpenRasta.Tests.Unit/Codecs/ApplicationXWwwUrlformEncodedCodec_Specification.cs
@@ -103,6 +103,17 @@ namespace ApplicationXWwwUrlformEncodedCodec_Specification
         }
 
         [Test]
+        public void invalid_nullable_guids_are_assigned()
+        {
+            given_context();
+            given_request_stream("myguid=xxx");
+
+            when_decoding<Guid?>("myguid");
+
+            then_decoding_result_is_missing();
+        }
+
+        [Test]
         public void integers_are_assigned()
         {
 

--- a/src/OpenRasta/TypeSystem/ReflectionBased/ReflectionExtensions.cs
+++ b/src/OpenRasta/TypeSystem/ReflectionBased/ReflectionExtensions.cs
@@ -425,7 +425,7 @@ namespace OpenRasta.TypeSystem.ReflectionBased
                 }
             }
 
-            if (type == typeof(Guid))
+            if (type == typeof(Guid) || type == typeof(Guid?))
             {
                 Guid validGuid;
                 if (!Guid.TryParse(propertyValue, out validGuid))


### PR DESCRIPTION
Currently Guid? also causes a 500 ... this should not be the case so adding this into the check as well.