### PR TITLE
Improve content disposition header parsing.

### DIFF
--- a/src/OpenRasta.Tests.Unit/Web/HttpHeaders_Specification.cs
+++ b/src/OpenRasta.Tests.Unit/Web/HttpHeaders_Specification.cs
@@ -43,6 +43,14 @@ namespace HttpHeaders_Specification
         }
 
         [Test]
+        public void fields_can_contain_semi_colons()
+        {
+            var header = new ContentDispositionHeader("form-data;filename=\"test;name\"");
+            header.FileName.
+                ShouldBe("test;name");
+        }
+
+        [Test]
         public void the_first_value_is_the_disposition()
         {
             var header = new ContentDispositionHeader("form-data");

--- a/src/OpenRasta/Web/ContentDispositionHeader.cs
+++ b/src/OpenRasta/Web/ContentDispositionHeader.cs
@@ -18,7 +18,7 @@ namespace OpenRasta.Web
 {
     public class ContentDispositionHeader: IEquatable<ContentDispositionHeader>
     {
-        private static readonly Regex SplitReg = new Regex(";(?=([^\"]*\"[^\"]*\")*[^\"]*$)");
+        private static readonly Regex SplitReg = new Regex(";(?=([^\"]*\"[^\"]*\")*[^\"]*$)", RegexOptions.Compiled);
 
         public ContentDispositionHeader(string header)
         {

--- a/src/OpenRasta/Web/ContentDispositionHeader.cs
+++ b/src/OpenRasta/Web/ContentDispositionHeader.cs
@@ -9,16 +9,21 @@
 #endregion
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using OpenRasta.Text;
 
 namespace OpenRasta.Web
 {
     public class ContentDispositionHeader: IEquatable<ContentDispositionHeader>
     {
+        private static readonly Regex SplitReg = new Regex(";(?=([^\"]*\"[^\"]*\")*[^\"]*$)");
+
         public ContentDispositionHeader(string header)
         {
-            var fragments = header.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            var fragments = SplitReg.Split(header).Where(f => !string.IsNullOrEmpty(f)).ToArray();
+                
             if (fragments.Length == 0)
                 throw new FormatException("The header value {0} is invalid for Content-Disposition.".With(header));
             Disposition = fragments[0].Trim();


### PR DESCRIPTION
Hi,

During uploads, we've noticed an issue where if any of the values in the Content-Disposition header contain semi colons, the upload fails with a 400 bad request.  Upon inspection it is because it can't find any content names, which is caused by the way the header is split by ';'.

I've updated to use a more robust regex, which ignores any quoted semi colons. Shamelessly stolen from here -> http://stackoverflow.com/questions/1757065/java-splitting-a-comma-separated-string-but-ignoring-commas-in-quotes

Cheers,

Richard