### PR TITLE
Cleaning up temp files

### DIFF
--- a/src/OpenRasta/IO/IFile.cs
+++ b/src/OpenRasta/IO/IFile.cs
@@ -69,13 +69,20 @@ namespace OpenRasta.IO
         public void Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         protected virtual void Dispose(bool disposing)
         {
             if (_disposed) return;
 
-            _stream.Dispose();
+            if (disposing)
+            {
+                if (_stream != null)
+                {
+                    _stream.Dispose();
+                }
+            }
             _disposed = true;
         }
     }

--- a/src/OpenRasta/IO/IFile.cs
+++ b/src/OpenRasta/IO/IFile.cs
@@ -15,7 +15,7 @@ using OpenRasta.Web;
 
 namespace OpenRasta.IO
 {
-    public interface IFile
+    public interface IFile : IDisposable
     {
         MediaType ContentType { get; }
         string FileName { get; }
@@ -51,6 +51,7 @@ namespace OpenRasta.IO
         }
 
         readonly Stream _stream;
+        bool _disposed;
         public MediaType ContentType { get; set; }
         public string FileName { get; set; }
         public long Length { get; set; }
@@ -63,6 +64,19 @@ namespace OpenRasta.IO
         string IReceivedFile.OriginalName
         {
             get { return FileName; }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed) return;
+
+            _stream.Dispose();
+            _disposed = true;
         }
     }
 #pragma warning restore 0618

--- a/src/OpenRasta/Pipeline/PipelineRunner.cs
+++ b/src/OpenRasta/Pipeline/PipelineRunner.cs
@@ -212,6 +212,16 @@ namespace OpenRasta.Pipeline
 
         protected virtual void FinishPipeline(ICommunicationContext context)
         {
+            if (context.Request.Entity != null)
+            {
+                context.Request.Entity.Dispose();
+            }
+
+            if (context.Response.Entity != null)
+            {
+                context.Response.Entity.Dispose();
+            }
+
             PipelineLog.WriteInfo("Pipeline finished.");
         }
 

--- a/src/OpenRasta/Web/HttpEntity.cs
+++ b/src/OpenRasta/Web/HttpEntity.cs
@@ -56,6 +56,7 @@ namespace OpenRasta.Web
         public void Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         private bool _disposed;
@@ -64,7 +65,13 @@ namespace OpenRasta.Web
         {
             if (_disposed) return;
 
-            Stream.Dispose();
+            if (disposing)
+            {
+                if (Stream != null)
+                {
+                    Stream.Dispose();
+                }
+            }
             _disposed = true;
         }
     }

--- a/src/OpenRasta/Web/HttpEntity.cs
+++ b/src/OpenRasta/Web/HttpEntity.cs
@@ -52,6 +52,21 @@ namespace OpenRasta.Web
 
         public Stream Stream { get; private set; }
         public IList<Error> Errors { get; set; }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        private bool _disposed;
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed) return;
+
+            Stream.Dispose();
+            _disposed = true;
+        }
     }
 }
 

--- a/src/OpenRasta/Web/HttpEntityFile.cs
+++ b/src/OpenRasta/Web/HttpEntityFile.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using OpenRasta.IO;
 
@@ -5,7 +6,9 @@ namespace OpenRasta.Web
 {
     public class HttpEntityFile : IFile
     {
-        readonly IHttpEntity _entity;
+        private bool _disposed;
+
+        private IHttpEntity _entity;
 
         public HttpEntityFile(IHttpEntity entity)
         {
@@ -30,6 +33,32 @@ namespace OpenRasta.Web
         public Stream OpenStream()
         {
             return _entity.Stream;
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~HttpEntityFile()
+        {
+            Dispose(false);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed) return;
+
+            if (disposing)
+            {
+                if (_entity != null)
+                {
+                    _entity.Dispose();
+                    _entity = null;
+                }
+                _disposed = true;
+            }
         }
     }
 }

--- a/src/OpenRasta/Web/HttpEntityFile.cs
+++ b/src/OpenRasta/Web/HttpEntityFile.cs
@@ -41,11 +41,6 @@ namespace OpenRasta.Web
             GC.SuppressFinalize(this);
         }
 
-        ~HttpEntityFile()
-        {
-            Dispose(false);
-        }
-
         protected virtual void Dispose(bool disposing)
         {
             if (_disposed) return;
@@ -57,8 +52,8 @@ namespace OpenRasta.Web
                     _entity.Dispose();
                     _entity = null;
                 }
-                _disposed = true;
             }
+            _disposed = true;
         }
     }
 }

--- a/src/OpenRasta/Web/IHttpEntity.cs
+++ b/src/OpenRasta/Web/IHttpEntity.cs
@@ -15,7 +15,7 @@ using OpenRasta.Codecs;
 
 namespace OpenRasta.Web
 {
-    public interface IHttpEntity
+    public interface IHttpEntity : IDisposable
     {
         ICodec Codec { get; set; }
         object Instance { get; set; }

--- a/src/OpenRasta/Web/MultipartHttpEntity.cs
+++ b/src/OpenRasta/Web/MultipartHttpEntity.cs
@@ -102,8 +102,8 @@ namespace OpenRasta.Web
                 }
 
                 CleanUpFile();
-                _disposed = true;
             }
+            _disposed = true;
         }
 
         private void CleanUpFile()


### PR DESCRIPTION
Hi,

We have an issue when uploading files, a temporary file is written to the temp directory and then never cleaned up.

Upon investigating, we found this thread: https://groups.google.com/forum/#!topic/openrasta/ZxUMvL2hHPA

The suggestion of making these things Disposable, and then disposing of them in the consumer was taken up, but the changes were put into a custom fork rather than submitted to OR proper.

As such, I've made the same changes here.

I also put calls to Dispose() in the FinishPipeline() method, as it made sense to me to clear these up at the end anyway.  (Note, this doesn't directly help us in our scenario, as we extract the MultiPartHttpEntity from the request content directly, and it never becomes the Request or Response Entity).

Happy to take advice on this change, but we are keen to turn it round fairly quickly.

Cheers,

Richard