### PR TITLE
Added support for HTTP Basic authentication based on pipeline contributor pattern

### DIFF
--- a/src/OpenRasta.Testing/Contexts/openrasta_context.cs
+++ b/src/OpenRasta.Testing/Contexts/openrasta_context.cs
@@ -216,6 +216,11 @@ namespace OpenRasta.Testing.Contexts
                     Roles = new string[0]
                 };
             }
+
+            public bool ValidatePassword(Credentials credentials, string suppliedPassword)
+            {
+                return (credentials.Password == suppliedPassword);
+            }
         }
 
         protected TestErrorCollector Errors { get; private set; }

--- a/src/OpenRasta.Tests.Unit/OpenRasta.Tests.Unit.csproj
+++ b/src/OpenRasta.Tests.Unit/OpenRasta.Tests.Unit.csproj
@@ -110,6 +110,7 @@
     <Compile Include="OperationModel\OperationHydration_Spec.cs" />
     <Compile Include="Pipeline\Contributors\AuthenticationChallenger_Specification.cs" />
     <Compile Include="Pipeline\Contributors\Authentication_Specification.cs" />
+    <Compile Include="Pipeline\Contributors\BasicAuthorizer_Specification.cs" />
     <Compile Include="Pipeline\Contributors\HandlerMethodFiltersInvoker_Specification.cs" />
     <Compile Include="Pipeline\Contributors\HandlerMethodInvoker_Specification.cs" />
     <Compile Include="Pipeline\Contributors\HandlerMethodrequestEntityResolver_Specification.cs" />

--- a/src/OpenRasta.Tests.Unit/Pipeline/Contributors/BasicAuthorizer_Specification.cs
+++ b/src/OpenRasta.Tests.Unit/Pipeline/Contributors/BasicAuthorizer_Specification.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Text;
+using Moq;
+using NUnit.Framework;
+using OpenRasta.Pipeline;
+using OpenRasta.Pipeline.Contributors;
+using OpenRasta.Security;
+using OpenRasta.Testing;
+using OpenRasta.Testing.Contexts;
+using OpenRasta.Web;
+
+namespace OpenRasta.Tests.Unit.Pipeline.Contributors
+{
+    [TestFixture]
+    public class BasicAuthorizer_Specification : openrasta_context
+    {
+        [Test]
+        [TestCase("username", "password")]
+        [TestCase("username", "")]
+        [TestCase("", "")]
+        [TestCase("username", "password:containing:colons")]
+        [TestCase("username", "pɹoʍssɐd ǝpoɔᴉun ɐ sᴉ sᴉɥʇ")]
+        public void BasicAuthorizer_Succeeds_For_Valid_Credentials(string username, string password)
+        {
+            var mockAuthenticationProvider = new Mock<IAuthenticationProvider>();
+            mockAuthenticationProvider.Setup(ap => ap.GetByUsername(username))
+                .Returns(new Credentials() { Username = username, Password = password });
+            mockAuthenticationProvider.Setup(ap => ap.ValidatePassword(It.IsAny<Credentials>(), It.IsAny<string>())).Returns(true);
+
+            given_dependency(mockAuthenticationProvider.Object);
+            given_pipeline_contributor<BasicAuthorizerContributor>();
+
+            Context.Request.Headers.Add("Authorization", "Basic " + Convert.ToBase64String(Encoding.ASCII.GetBytes(username + ":" + password)));
+
+            var result = when_sending_notification<KnownStages.IHandlerSelection>();
+            result.ShouldBe(PipelineContinuation.Continue);
+            Context.User.Identity.Name.ShouldBe(username);
+        }
+
+        [Test]
+        public void BasicAuthorizer_Returns_Authenticate_Header_For_Invalid_Credentials()
+        {
+            var mockAuthenticationProvider = new Mock<IAuthenticationProvider>();
+            mockAuthenticationProvider.Setup(ap => ap.GetByUsername(It.IsAny<string>())).Returns(new Credentials());
+            mockAuthenticationProvider.Setup(ap => ap.ValidatePassword(It.IsAny<Credentials>(), It.IsAny<string>())).Returns(false);
+            given_dependency(mockAuthenticationProvider.Object);
+            given_pipeline_contributor<BasicAuthorizerContributor>();
+            Context.Request.Headers.Add("Authorization", "Basic " + Convert.ToBase64String(Encoding.ASCII.GetBytes("username:password")));
+            var result = when_sending_notification<KnownStages.IHandlerSelection>();
+            result.ShouldBe(PipelineContinuation.RenderNow);
+            Context.OperationResult.ShouldBeOfType<OperationResult.Unauthorized>();
+            Context.User.ShouldBe(null);
+        }
+
+        [Test]
+        [TestCase("Basic THIS_IS_NOT_A_BASE64_ENCODED_CREDENTIAL")]
+        [TestCase("Invalid Header")]
+        public void BasicAuthorizer_Returns_Unauthorized_When_Header_Is_Invalid(string header)
+        {
+            var mockAuthenticationProvider = new Mock<IAuthenticationProvider>();
+            given_dependency(mockAuthenticationProvider.Object);
+            given_pipeline_contributor<BasicAuthorizerContributor>();
+
+            Context.Request.Headers.Add("Authorization", header);
+
+            var result = when_sending_notification<KnownStages.IHandlerSelection>();
+            result.ShouldBe(PipelineContinuation.RenderNow);
+            Context.OperationResult.ShouldBeOfType<OperationResult.Unauthorized>();
+        }
+
+        [Test]
+        public void BasicAuthorizer_Sends_WwwAuthenticate_For_Missing_Credentials()
+        {
+            var mockAuthenticationProvider = new Mock<IAuthenticationProvider>();
+            given_dependency(mockAuthenticationProvider.Object);
+            given_pipeline_contributor<BasicAuthorizerContributor>();
+
+            when_sending_notification<KnownStages.IHandlerSelection>();
+            when_sending_notification<KnownStages.IOperationResultInvocation>();
+            var header = String.Format("Basic realm=\"{0}\"", BasicAuthenticationRequiredHeader.DEFAULT_REALM);
+            Context.Response.Headers["WWW-Authenticate"].ShouldBe(header);
+        }
+
+        [Test]
+        public void BasicAuthorizer_Returns_NotAuthorized_For_Missing_Credentials()
+        {
+            var mockAuthenticationProvider = new Mock<IAuthenticationProvider>();
+            given_dependency(mockAuthenticationProvider.Object);
+            given_pipeline_contributor<BasicAuthorizerContributor>();
+
+            var result = when_sending_notification<KnownStages.IHandlerSelection>();
+            result.ShouldBe(PipelineContinuation.RenderNow);
+            Context.OperationResult.ShouldBeOfType<OperationResult.Unauthorized>();
+        }
+    }
+}

--- a/src/OpenRasta/OpenRasta.csproj
+++ b/src/OpenRasta/OpenRasta.csproj
@@ -279,6 +279,7 @@
     <Compile Include="Pipeline\Contributors\AuthenticationChallengerContributor.cs" />
     <Compile Include="Pipeline\Contributors\AuthenticationContributor.cs" />
     <Compile Include="Pipeline\Contributors\BootstrapperContributor.cs" />
+    <Compile Include="Pipeline\Contributors\BasicAuthorizerContributor.cs" />
     <Compile Include="Pipeline\Contributors\DigestAuthorizerContributor.cs" />
     <Compile Include="Pipeline\Contributors\EndContributor.cs" />
     <Compile Include="Pipeline\Contributors\HandlerResolverContributor.cs" />
@@ -323,6 +324,8 @@
     <Compile Include="Reflection\ScopedDictionary.cs" />
     <Compile Include="Resources\Files.Designer.cs" />
     <Compile Include="Security\Credentials.cs" />
+    <Compile Include="Security\BasicAuthenticationRequiredHeader.cs" />
+    <Compile Include="Security\BasicAuthorizationHeader.cs" />
     <Compile Include="Security\DigestHeader.cs" />
     <Compile Include="Security\IAuthenticationProvider.cs" />
     <Compile Include="Security\PrincipalAuthorizationAttribute.cs" />

--- a/src/OpenRasta/Pipeline/Contributors/BasicAuthorizerContributor.cs
+++ b/src/OpenRasta/Pipeline/Contributors/BasicAuthorizerContributor.cs
@@ -1,0 +1,135 @@
+#region License
+
+/* Authors:
+ *      Dylan Beattie (dylan@dylanbeattie.net)
+ *      Sebastien Lambla (seb@serialseb.com)
+ * Copyright:
+ *      (C) 2007-2015 Caffeine IT & naughtyProd Ltd (http://www.caffeine-it.com)
+ * License:
+ *      This file is distributed under the terms of the MIT License found at the end of this file.
+ */
+
+#endregion
+
+// HTTP Basic Authentication implementation 
+// Adapts approach used in https://github.com/scottlittlewood/OpenRastaAuthSample to support pipeline contributor model.
+
+using System;
+using System.Linq;
+using System.Security.Principal;
+using OpenRasta.DI;
+using OpenRasta.Security;
+using OpenRasta.Web;
+using OpenRasta.Pipeline;
+
+namespace OpenRasta.Pipeline.Contributors
+{
+    public class BasicAuthorizerContributor : IPipelineContributor
+    {
+        public const string REALM = "Basic Authentication";
+
+        private readonly IDependencyResolver _resolver;
+        private IAuthenticationProvider _authentication;
+
+        public BasicAuthorizerContributor(IDependencyResolver resolver)
+        {
+            _resolver = resolver;
+        }
+
+        public void Initialize(IPipeline pipelineRunner)
+        {
+            _authentication = _resolver.Resolve<IAuthenticationProvider>();
+            pipelineRunner.Notify(ReadCredentials)
+                .After<KnownStages.IBegin>()
+                .And
+                .Before<KnownStages.IHandlerSelection>();
+
+            pipelineRunner.Notify(WriteCredentialRequest)
+                .After<KnownStages.IOperationResultInvocation>()
+                .And
+                .Before<KnownStages.IResponseCoding>();
+        }
+
+        public PipelineContinuation ReadCredentials(ICommunicationContext context)
+        {
+            if (!_resolver.HasDependency(typeof(IAuthenticationProvider)))
+            {
+                return NotAuthorized(context);
+            }
+
+            _authentication = _resolver.Resolve<IAuthenticationProvider>();
+
+            try
+            {
+                var header = ReadBasicAuthHeader(context);
+
+                if (header == null)
+                {
+                    return NotAuthorized(context);
+                }
+
+                var credentials = _authentication.GetByUsername(header.Username);
+
+                if (credentials == null)
+                {
+                    return NotAuthorized(context);
+                }
+
+                if (!_authentication.ValidatePassword(credentials, header.Password))
+                {
+                    return NotAuthorized(context);
+                }
+                IIdentity id = new GenericIdentity(credentials.Username, "Basic");
+                context.User = new GenericPrincipal(id, credentials.Roles);
+                return PipelineContinuation.Continue;
+            } 
+            catch (ArgumentException ex)
+            {
+                return NotAuthorized(context);
+            }
+        }
+
+        private static BasicAuthorizationHeader ReadBasicAuthHeader(ICommunicationContext context)
+        {
+            var header = context.Request.Headers["Authorization"];
+            return string.IsNullOrEmpty(header) ? null : BasicAuthorizationHeader.Parse(header);
+        }
+
+        private static PipelineContinuation NotAuthorized(ICommunicationContext context)
+        {
+            context.OperationResult = new OperationResult.Unauthorized();
+            return PipelineContinuation.RenderNow;
+        }
+
+        private static PipelineContinuation WriteCredentialRequest(ICommunicationContext context)
+        {
+            if (context.OperationResult is OperationResult.Unauthorized)
+            {
+                var header = new BasicAuthenticationRequiredHeader().ServerResponseHeader;
+                context.Response.Headers["WWW-Authenticate"] = header;
+            }
+            return PipelineContinuation.Continue;
+        }
+    }
+}
+
+#region Full license
+
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#endregion

--- a/src/OpenRasta/Security/BasicAuthenticationRequiredHeader.cs
+++ b/src/OpenRasta/Security/BasicAuthenticationRequiredHeader.cs
@@ -1,0 +1,60 @@
+#region License
+
+/* Authors:
+ *      Dylan Beattie (dylan@dylanbeattie.net)
+ *      Sebastien Lambla (seb@serialseb.com)
+ * Copyright:
+ *      (C) 2007-2009 Caffeine IT & naughtyProd Ltd (http://www.caffeine-it.com)
+ * License:
+ *      This file is distributed under the terms of the MIT License found at the end of this file.
+ */
+
+#endregion
+
+using System;
+
+namespace OpenRasta.Security
+{
+    /// <summary>
+    /// Represents an HTTP Basic authentication header
+    /// </summary>
+    public class BasicAuthenticationRequiredHeader
+    {
+        public const string DEFAULT_REALM = "HTTP Basic";
+
+        public BasicAuthenticationRequiredHeader() : this(DEFAULT_REALM) {}
+
+        public BasicAuthenticationRequiredHeader(string realm)
+        {
+            this.Realm = realm;
+        }
+
+        public string Realm { get; set; }
+
+        public string ServerResponseHeader
+        {
+            get { return (String.Format("Basic realm=\"{0}\"", Realm)); }
+        }
+    }
+}
+
+#region Full license
+
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#endregion

--- a/src/OpenRasta/Security/BasicAuthorizationHeader.cs
+++ b/src/OpenRasta/Security/BasicAuthorizationHeader.cs
@@ -1,0 +1,74 @@
+#region License
+
+/* Authors:
+ *      Dylan Beattie (dylan@dylanbeattie.net)
+ *      Sebastien Lambla (seb@serialseb.com)
+ * Copyright:
+ *      (C) 2007-2015 Caffeine IT & naughtyProd Ltd (http://www.caffeine-it.com)
+ * License:
+ *      This file is distributed under the terms of the MIT License found at the end of this file.
+ */
+
+#endregion
+
+using System;
+using System.Text;
+
+namespace OpenRasta.Security
+{
+    public class BasicAuthorizationHeader
+    {
+        private BasicAuthorizationHeader(string username, string password)
+        {
+            this.Username = username;
+            this.Password = password;
+        }
+
+        public string Username { get; set; }
+        public string Password { get; set; }
+
+        public static BasicAuthorizationHeader Parse(string header)
+        {
+            var tokens = header.Split(' ');
+            if (tokens.Length != 2)
+            {
+                throw (new ArgumentException("Supplied header is not in the format Basic {base64-encoded credential pair}", "header"));
+            }
+            if (tokens[0] != "Basic")
+            {
+                throw (new ArgumentException("Supplied header is not an HTTP Basic authorization header", header));
+            }
+            try
+            {
+                var credentialString = Encoding.UTF8.GetString(Convert.FromBase64String(tokens[1]));
+
+                var credentials = credentialString.Split(new[] { ':' }, 2);
+                return (new BasicAuthorizationHeader(credentials[0], credentials[1]));
+            } catch (FormatException ex)
+            {
+                throw (new ArgumentException("Supplied header doesn't contain valid base64 encoded credentials", ex));
+            }
+        }
+    }
+}
+
+#region Full license
+
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#endregion

--- a/src/OpenRasta/Security/IAuthenticationProvider.cs
+++ b/src/OpenRasta/Security/IAuthenticationProvider.cs
@@ -7,6 +7,7 @@
  * License:
  *      This file is distributed under the terms of the MIT License found at the end of this file.
  */
+
 #endregion
 
 namespace OpenRasta.Security
@@ -14,6 +15,12 @@ namespace OpenRasta.Security
     public interface IAuthenticationProvider
     {
         Credentials GetByUsername(string p);
+
+        /// <summary>Returns true if the supplied password matches the password stored in the specified credentials; otherwise false.</summary>
+        /// <param name="credentials">A set of <see cref="Credentials"/> containing authentication details (e.g. from your application's security database)</param>
+        /// <param name="suppliedPassword">The plaintext password supplied by the user who is trying to authenticate.</param>
+        /// <returns>True if the supplied password matches the credential; otherwise false.</returns>
+        bool ValidatePassword(Credentials credentials, string suppliedPassword);
     }
 }
 


### PR DESCRIPTION
Adds a new BasicAuthorizerContributor class that implemented HTTP Basic authentication as part of the request pipeline.

### Configuration: 
```
public class Configuration : IConfigurationSource {
        public void Configure() {
            using (OpenRastaConfiguration.Manual) {
                ResourceSpace.Uses.CustomDependency<IAuthenticationProvider, AuthenticationProvider>(DependencyLifetime.Singleton);
                ResourceSpace.Uses.PipelineContributor<BasicAuthorizerContributor>();
             }
        }
    }
```
### Implementing AuthenticationProvider
```
    public class AuthenticationProvider : IAuthenticationProvider {
        private readonly IDataStore db;

        public AuthenticationProvider(IDataStore db) {
            this.db = db;
        }

        public Credentials GetByUsername(string username) {
            var user = db.FindUserByUsername(username);
            if (user == null) return (null);
            return (new Credentials() {
                Username = user.Username,
                Password = user.Password,
                Roles = new string[] { }
            });
        }

        public bool ValidatePassword(Credentials credentials, string suppliedPassword) {
            return (credentials.Password == suppliedPassword);
        }
    }
```
### Implementing handlers that require authentication
```
    [RequiresAuthentication]
    public class WhoAmIHandler {
        private readonly IDataStore db;
        private readonly ICommunicationContext context;

        public WhoAmIHandler(IDataStore db, ICommunicationContext context) {
            this.db = db;
            this.context = context;
        }

        public object Get() {
            var userRecord = db.FindUserByUsername(context.User.Identity.Name);
            return (new WhoAmIResponse(userRecord.Id, userRecord.Username, userRecord.Name));
        }
    }
```

