### PR TITLE
OperationFilterContributor: filter out duplicate operations

### DIFF
--- a/src/OpenRasta/Pipeline/Contributors/OperationFilterContributor.cs
+++ b/src/OpenRasta/Pipeline/Contributors/OperationFilterContributor.cs
@@ -32,7 +32,7 @@ namespace OpenRasta.Pipeline.Contributors
       return _operationProcessors()
         .Aggregate(
           operations = operations.ToList(),
-          (ops, filter) => filter.Process(ops));
+          (ops, filter) => filter.Process(ops)).Distinct();
     }
 
     public void Initialize(IPipeline pipelineRunner)


### PR DESCRIPTION
We're running into an issue where `UriParametersFilter` is yielding each operation twice, due to [this loop](https://github.com/openrasta/openrasta-core/blob/master/src/OpenRasta/OperationModel/Filters/UriParametersFilter.cs#L43) iterating twice for each. It's definitely worth digging into that a bit more to figure out what's changed, but per our conversation in Gitter here's a interim hack that gets it working again in the meantime.