### PR TITLE
ContentLength is not available in Kestrel

### DIFF
--- a/src/OpenRasta/Hosting/Owin/OwinRequest.cs
+++ b/src/OpenRasta/Hosting/Owin/OwinRequest.cs
@@ -30,11 +30,12 @@ namespace OpenRasta.Hosting.Katana
     void PopulateHeaders(IOwinRequest ctx)
     {
       var headerCollection = new NameValueCollection();
-      foreach (var header in ctx.Headers) headerCollection.Add(header.Key, header.Value.First());
+      foreach (var header in ctx.Headers)
+      {
+        headerCollection.Add(header.Key, header.Value.First());
+      }
 
       Headers = new HttpHeaderDictionary(headerCollection);
-
-      if (Headers.ContentLength == null) Headers.ContentLength = ctx.Body.Length;
     }
   }
 }


### PR DESCRIPTION
Small change to get the Owin hosting running on Kestrel, we it can be hosted on linux or osx
