### PR TITLE
Changes to DI func<> tests so they can be reused like previous DI tests

### DIFF
--- a/src/OpenRasta.Tests.Unit/DI/registration_depending_on_enum_of_unregistered_after_registration.cs
+++ b/src/OpenRasta.Tests.Unit/DI/registration_depending_on_enum_of_unregistered_after_registration.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using InternalDependencyResolver_Specification;
+using NUnit.Framework;
+using OpenRasta.DI;
+using Shouldly;
+
+namespace OpenRasta.Tests.Unit.DI
+{
+  public abstract class registration_depending_on_enum_of_unregistered_after_registration: dependency_resolver_context
+  {
+    [Test]
+    public void func_is_resolved()
+    {
+      var factory = Resolver.Resolve<Func<IEnumerable<Simple>>>();
+      Resolver.AddDependency<Simple>();
+      factory().ShouldHaveSingleItem().ShouldNotBeNull();
+    }
+  }
+}

--- a/src/OpenRasta.Tests.Unit/DI/registration_depending_on_enum_of_unregistered_after_registration_with_internal_dependency_resolver.cs
+++ b/src/OpenRasta.Tests.Unit/DI/registration_depending_on_enum_of_unregistered_after_registration_with_internal_dependency_resolver.cs
@@ -1,0 +1,9 @@
+﻿using OpenRasta.DI;
+
+namespace OpenRasta.Tests.Unit.DI
+{
+  public  class registration_depending_on_enum_of_unregistered_after_registration_with_internal_dependency_resolver : registration_depending_on_enum_of_unregistered_after_registration
+  {
+    public override IDependencyResolver CreateResolver() { return new InternalDependencyResolver(); }
+  }
+}

--- a/src/OpenRasta.Tests.Unit/DI/registration_depending_on_func_in_other_scope.cs
+++ b/src/OpenRasta.Tests.Unit/DI/registration_depending_on_func_in_other_scope.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using InternalDependencyResolver_Specification;
+using NUnit.Framework;
+using OpenRasta.DI;
+using OpenRasta.Hosting;
+using OpenRasta.Pipeline;
+using Shouldly;
+
+namespace OpenRasta.Tests.Unit.DI
+{
+  public abstract class registration_depending_on_func_in_other_scope : dependency_resolver_context
+  {
+    [Test]
+    public void resolve_succeeds()
+    {
+      Resolver.AddDependency<IContextStore, AmbientContextStore>();
+      
+      Resolver.AddDependency<Contributor>(DependencyLifetime.Singleton);
+      Resolver.AddDependency<ErrorCollector>(DependencyLifetime.Transient);
+
+      var contributor = Resolver.Resolve<Contributor>();
+      using(new ContextScope(new AmbientContext()))
+      using (Resolver.CreateRequestScope())
+      {
+        Resolver.AddDependencyInstance(new Request(), DependencyLifetime.PerRequest);
+        var result = contributor.Factory();
+        result.ShouldHaveSingleItem();
+      }
+    }
+    class Request{}
+
+    class ErrorCollector
+    {
+      public ErrorCollector(Request request)
+      {
+      }
+    }
+
+    class Contributor
+    {
+      public Func<IEnumerable<ErrorCollector>> Factory { get; }
+
+      public Contributor(Func<IEnumerable<ErrorCollector>> factory)
+      {
+        Factory = factory;
+      }
+    }
+  }
+}

--- a/src/OpenRasta.Tests.Unit/DI/registration_depending_on_func_in_other_scope.cs
+++ b/src/OpenRasta.Tests.Unit/DI/registration_depending_on_func_in_other_scope.cs
@@ -28,9 +28,9 @@ namespace OpenRasta.Tests.Unit.DI
         result.ShouldHaveSingleItem();
       }
     }
-    class Request{}
+    public class Request{}
 
-    class ErrorCollector
+    public class ErrorCollector
     {
       public ErrorCollector(Request request)
       {

--- a/src/OpenRasta.Tests.Unit/DI/registration_depending_on_func_in_other_scope_with_internal_dependency_resolver.cs
+++ b/src/OpenRasta.Tests.Unit/DI/registration_depending_on_func_in_other_scope_with_internal_dependency_resolver.cs
@@ -1,0 +1,9 @@
+﻿using OpenRasta.DI;
+
+namespace OpenRasta.Tests.Unit.DI
+{
+  public class registration_depending_on_func_in_other_scope_with_internal_dependency_resolver: registration_depending_on_func_in_other_scope
+  {
+    public override IDependencyResolver CreateResolver() { return new InternalDependencyResolver(); }
+  }
+}

--- a/src/OpenRasta.Tests.Unit/DI/registration_depending_on_func_of_unregistered.cs
+++ b/src/OpenRasta.Tests.Unit/DI/registration_depending_on_func_of_unregistered.cs
@@ -2,72 +2,26 @@
 using System.Collections.Generic;
 using NUnit.Framework;
 using OpenRasta.DI;
-using OpenRasta.Hosting;
-using OpenRasta.Pipeline;
 using Shouldly;
+using InternalDependencyResolver_Specification;
 
 namespace OpenRasta.Tests.Unit.DI
 {
-  public class registration_depending_on_func_in_other_scope
+  public abstract class registration_depending_on_func_of_unregistered : dependency_resolver_context
   {
-    [Test]
-    public void resolve_succeeds()
-    {
-      var resolver = new InternalDependencyResolver();
-      resolver.AddDependency<IContextStore, AmbientContextStore>();
-      
-      resolver.AddDependency<Contributor>(DependencyLifetime.Singleton);
-      resolver.AddDependency<ErrorCollector>(DependencyLifetime.Transient);
-
-      var contributor = resolver.Resolve<Contributor>();
-      using(new ContextScope(new AmbientContext()))
-      using (resolver.CreateRequestScope())
-      {
-        resolver.AddDependencyInstance(new Request(), DependencyLifetime.PerRequest);
-        var result = contributor.Factory();
-        result.ShouldHaveSingleItem();
-      }
-    }
-    class Request{}
-
-    class ErrorCollector
-    {
-      public ErrorCollector(Request request)
-      {
-      }
-    }
-
-    class Contributor
-    {
-      public Func<IEnumerable<ErrorCollector>> Factory { get; }
-
-      public Contributor(Func<IEnumerable<ErrorCollector>> factory)
-      {
-        Factory = factory;
-      }
-    }
-  }
-
-  public class registration_depending_on_func_of_unregistered
-  {
-    readonly InternalDependencyResolver resolver;
-
-    public registration_depending_on_func_of_unregistered()
-    {
-      resolver = new InternalDependencyResolver();
-      resolver.AddDependency<DependsOnFuncOfSimple>();
-    }
-
     [Test]
     public void can_resolve_type()
     {
-      Should.NotThrow(() => resolver.Resolve<DependsOnFuncOfSimple>());
+      Resolver.AddDependency<DependsOnFuncOfSimple>();
+      Should.NotThrow(() => Resolver.Resolve<DependsOnFuncOfSimple>());
     }
 
     [Test]
-    public void cannot_resolve_func_before_type_is_registered()
+    public virtual void cannot_resolve_func_before_type_is_registered()
     {
-      var dependent = resolver.Resolve<DependsOnFuncOfSimple>();
+      Resolver.AddDependency<DependsOnFuncOfSimple>();
+
+      var dependent = Resolver.Resolve<DependsOnFuncOfSimple>();
       Should.Throw<DependencyResolutionException>(() =>
       {
         var simple = dependent.Simple();
@@ -76,7 +30,7 @@ namespace OpenRasta.Tests.Unit.DI
     }
   }
 
-  class DependsOnFuncOfSimple
+  public class DependsOnFuncOfSimple
   {
     public DependsOnFuncOfSimple(Func<Simple> simple)
     {

--- a/src/OpenRasta.Tests.Unit/DI/registration_depending_on_func_of_unregistered_after_registration.cs
+++ b/src/OpenRasta.Tests.Unit/DI/registration_depending_on_func_of_unregistered_after_registration.cs
@@ -1,40 +1,22 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using InternalDependencyResolver_Specification;
 using NUnit.Framework;
 using OpenRasta.DI;
 using Shouldly;
 
 namespace OpenRasta.Tests.Unit.DI
 {
-  class registration_depending_on_func_of_unregistered_after_registration
+  public abstract class registration_depending_on_func_of_unregistered_after_registration : dependency_resolver_context
   {
-    InternalDependencyResolver resolver;
     DependsOnFuncOfSimple instance;
 
-    public registration_depending_on_func_of_unregistered_after_registration()
-    {
-      resolver = new InternalDependencyResolver();
-      resolver.AddDependency<DependsOnFuncOfSimple>();
-      instance = resolver.Resolve<DependsOnFuncOfSimple>();
-      resolver.AddDependency<Simple>();
-    }
-
     [Test]
     public void func_is_resolved()
     {
+      Resolver.AddDependency<DependsOnFuncOfSimple>();
+      instance = Resolver.Resolve<DependsOnFuncOfSimple>();
+      Resolver.AddDependency<Simple>();
+
       instance.Simple().ShouldNotBeNull();
-    }
-  }
-
-  class registration_depending_on_enum_of_unregistered_after_registration
-  {
-    [Test]
-    public void func_is_resolved()
-    {
-      var resolver = new InternalDependencyResolver();
-      var factory = resolver.Resolve<Func<IEnumerable<Simple>>>();
-      resolver.AddDependency<Simple>();
-      factory().ShouldHaveSingleItem().ShouldNotBeNull();
     }
   }
 }

--- a/src/OpenRasta.Tests.Unit/DI/registration_depending_on_func_of_unregistered_after_registration_with_internal_dependency_resolver.cs
+++ b/src/OpenRasta.Tests.Unit/DI/registration_depending_on_func_of_unregistered_after_registration_with_internal_dependency_resolver.cs
@@ -1,0 +1,9 @@
+﻿using OpenRasta.DI;
+
+namespace OpenRasta.Tests.Unit.DI
+{
+  public  class registration_depending_on_func_of_unregistered_after_registration_with_internal_dependency_resolver : registration_depending_on_func_of_unregistered_after_registration
+  {
+    public override IDependencyResolver CreateResolver() { return new InternalDependencyResolver(); }
+  }
+}

--- a/src/OpenRasta.Tests.Unit/DI/registration_depending_on_func_of_unregistered_with_internal_dependency_resolver.cs
+++ b/src/OpenRasta.Tests.Unit/DI/registration_depending_on_func_of_unregistered_with_internal_dependency_resolver.cs
@@ -1,0 +1,13 @@
+﻿using InternalDependencyResolver_Specification;
+using OpenRasta.DI;
+
+namespace OpenRasta.Tests.Unit.DI
+{
+  public class registration_depending_on_func_of_unregistered_with_internal_dependency_resolver : dependency_resolver_context
+  {
+    public override IDependencyResolver CreateResolver()
+    {
+      return new InternalDependencyResolver();
+    }
+  }
+}

--- a/src/OpenRasta.Tests.Unit/DI/registration_profiles.cs
+++ b/src/OpenRasta.Tests.Unit/DI/registration_profiles.cs
@@ -1,27 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
+using InternalDependencyResolver_Specification;
 using NUnit.Framework;
 using OpenRasta.DI;
 using Shouldly;
 
 namespace OpenRasta.Tests.Unit.DI
 {
-  public class registration_profiles
+  public abstract class registration_profiles : dependency_resolver_context
   {
-    InternalDependencyResolver resolver;
-
-    public registration_profiles()
-    {
-      resolver = new InternalDependencyResolver();
-      resolver.AddDependency<Simple>();
-    }
-
     [Test]
     public void resolving_funcs()
     {
+      Resolver.AddDependency<Simple>();
+
       Should.NotThrow(() =>
       {
-        var factory = resolver.Resolve<Func<Simple>>();
+        var factory = Resolver.Resolve<Func<Simple>>();
         return factory();
       });
     }
@@ -29,21 +24,24 @@ namespace OpenRasta.Tests.Unit.DI
     [Test]
     public void resolving_enums()
     {
-      Should.NotThrow(() => resolver.Resolve<IEnumerable<Simple>>().ShouldHaveSingleItem().ShouldNotBeNull());
+      Resolver.AddDependency<Simple>();
+      Should.NotThrow(() => Resolver.Resolve<IEnumerable<Simple>>().ShouldHaveSingleItem().ShouldNotBeNull());
     }
 
     [Test]
     public void resolving_func_of_enums()
     {
-      Should.NotThrow(() => resolver.Resolve<Func<IEnumerable<Simple>>>()().ShouldHaveSingleItem().ShouldNotBeNull());
+      Resolver.AddDependency<Simple>();
+      Should.NotThrow(() => Resolver.Resolve<Func<IEnumerable<Simple>>>()().ShouldHaveSingleItem().ShouldNotBeNull());
     }
     
     [Test, Ignore("This won't work yet, needs refactoring")]
     public void resolving_enum_of_func()
     {
+      Resolver.AddDependency<Simple>();
       Should.NotThrow(() =>
       {
-        var enumerable = resolver.Resolve<IEnumerable<Func<Simple>>>();
+        var enumerable = Resolver.Resolve<IEnumerable<Func<Simple>>>();
         var func = enumerable.ShouldHaveSingleItem();
         func();
       });

--- a/src/OpenRasta.Tests.Unit/DI/registration_profiles_with_internal_dependency_resolver.cs
+++ b/src/OpenRasta.Tests.Unit/DI/registration_profiles_with_internal_dependency_resolver.cs
@@ -1,0 +1,12 @@
+﻿using OpenRasta.DI;
+
+namespace OpenRasta.Tests.Unit.DI
+{
+  public class registration_profiles_with_internal_dependency_resolver : registration_profiles
+  {
+    public override IDependencyResolver CreateResolver()
+    {
+      return new InternalDependencyResolver(); 
+    }
+  }
+}


### PR DESCRIPTION
The Windsor DI was missing all the new Func<> tests.
I've done the working in the windsor DI to support func<> https://github.com/openrasta/openrasta-castle-windsor/commit/db2431fdcd7f8593d27d4d7e96460939873a9d3b
And have made the testing in OR shareable with Windsor DI project.

The only "real" code change I had to make was  the second commit which changes 2 class to public. If you don't Windsor throws and error 
```
Attempt by method 'Castle.Proxies.Func`1Proxy.Invoke()' to access type 'System.Collections.Generic.IEnumerable`1 failed. at Castle.Proxies.Func`1Proxy.Invoke()
```
It does not seem to be able to access the method if the classes are not public.


 - [x] the code
 - [ ] If it's a non-trivial piece of code, signing a CLA
 - [ ] If it breaks, change, fix or add to existing behaviour, updating
       CHANGELOG.md
 - [x ] If it's a bug fix, tests in the Tests `project`, or scenarios in the `TestRig`.
 - [ ] On top of HEAD, unless it's a bugfix on a previous version
 - [ ] VERSION file updated if not creating a pull-request on top of `master`

