### PR TITLE
WIP Add checks for transfer-encoding header, TRACE method in RequestCodeSelector

### DIFF
--- a/src/OpenRasta.Tests.Unit/OperationModel/CodecSelectors/RequestCodecSelector_Specification.cs
+++ b/src/OpenRasta.Tests.Unit/OperationModel/CodecSelectors/RequestCodecSelector_Specification.cs
@@ -27,11 +27,58 @@ namespace OpenRasta.Tests.Unit.OperationModel.CodecSelectors
 
       when_filtering_operations();
 
-      FilteredOperations.Count().ShouldBe(2);
+      FilteredOperations.Count().ShouldBe(3);
 
       then_operation_should_be_selected("Get");
       codec_is_not_assigned("Get");
       then_operation_should_be_selected("GetWithOptionalValue");
+    }
+    
+    [Test]
+    public void only_operations_already_ready_for_invocation_get_returned_for_no_content_length()
+    {
+      given_filter();
+      given_operations();
+
+      when_filtering_operations();
+
+      FilteredOperations.Count().ShouldBe(3);
+
+      then_operation_should_be_selected("Get");
+      codec_is_not_assigned("Get");
+      then_operation_should_be_selected("GetWithOptionalValue");
+    }
+
+    [Test]
+    public void only_operations_already_ready_for_invocation_get_returned_for_TRACE_requests()
+    {
+      given_request_httpmethod("TRACE");
+      given_filter();
+      given_operations();
+
+      when_filtering_operations();
+
+      FilteredOperations.Count().ShouldBe(3);
+
+      then_operation_should_be_selected("Trace");
+      codec_is_not_assigned("Trace");
+    }
+    
+    [Test]
+    public void only_operations_already_ready_for_invocation_get_returned_for_TransferEncoding_requests()
+    {
+      Context.Request.Headers.Add("transfer-encoding","");
+      given_request_httpmethod("POST");
+      given_request_entity_body("hello world");
+      given_filter();
+      given_operations();
+
+      when_filtering_operations();
+
+      FilteredOperations.Count().ShouldBe(3);
+
+      then_operation_should_be_selected("Post");
+      codec_is_not_assigned("Post");
     }
 
     void then_operation_should_be_selected(string methodName)
@@ -148,6 +195,11 @@ namespace OpenRasta.Tests.Unit.OperationModel.CodecSelectors
 
     public void Post(string value)
     {
+    }
+
+    public object Trace()
+    {
+      return null;
     }
 
     public void PostForStream(Stream stream)

--- a/src/OpenRasta/OperationModel/CodecSelectors/RequestCodecSelector.cs
+++ b/src/OpenRasta/OperationModel/CodecSelectors/RequestCodecSelector.cs
@@ -28,7 +28,7 @@ namespace OpenRasta.OperationModel.CodecSelectors
 
         public IEnumerable<IOperationAsync> Process(IEnumerable<IOperationAsync> operations)
         {
-            if (_request.Entity.ContentLength == 0)
+            if (_request.HttpMethod == "TRACE" || _request.Entity.Headers.ContainsKey("transfer-encoding") || _request.Entity.ContentLength == 0)
                 return LogSelected(operations.Where(operation => operation.Inputs.AllReady()));
 
             var requestMediaType = _request.Entity.ContentType ?? DetectMediaType();

--- a/src/OpenRasta/OperationModel/CodecSelectors/RequestCodecSelector.cs
+++ b/src/OpenRasta/OperationModel/CodecSelectors/RequestCodecSelector.cs
@@ -28,7 +28,7 @@ namespace OpenRasta.OperationModel.CodecSelectors
 
         public IEnumerable<IOperationAsync> Process(IEnumerable<IOperationAsync> operations)
         {
-            if (_request.HttpMethod == "TRACE" || _request.Entity.Headers.ContainsKey("transfer-encoding") || _request.Entity.ContentLength == 0)
+            if (_request.HttpMethod == "TRACE" || _request.Entity.Headers.ContainsKey("transfer-encoding") || _request.Entity.ContentLength.IsNullOr(0))
                 return LogSelected(operations.Where(operation => operation.Inputs.AllReady()));
 
             var requestMediaType = _request.Entity.ContentType ?? DetectMediaType();


### PR DESCRIPTION
Opening this as WIP & discussion

I was trying to find the best place to add some tests which I think is here https://github.com/openrasta/openrasta-core/blob/7c453686dbc1bb02188775961b6a2c255f4d97bf/src/OpenRasta.Tests.Unit/OperationModel/CodecSelectors/RequestCodecSelector_Specification.cs#L22 ??

