### PR TITLE
Discovered a bug with KeepAlives

### DIFF
--- a/OpenRasta.sln
+++ b/OpenRasta.sln
@@ -37,15 +37,19 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenRasta.DI.Windsor.Tests.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenRasta.Hosting.AspNet.Tests.Integration", "src\OpenRasta.Hosting.AspNet.Tests.Integration\OpenRasta.Hosting.AspNet.Tests.Integration.csproj", "{088478E0-A0CB-40E1-88C6-A89B50330C6B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenRasta.Plugins.Hydra", "src\OpenRasta.Plugins.Hydra\OpenRasta.Plugins.Hydra.csproj", "{05AD6BA1-C771-41DC-94B5-5D4CA2C8DB2F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenRasta.Plugins.Hydra", "src\OpenRasta.Plugins.Hydra\OpenRasta.Plugins.Hydra.csproj", "{05AD6BA1-C771-41DC-94B5-5D4CA2C8DB2F}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Benchmarks", "Benchmarks", "{F29C9EB9-4B9A-4D8D-A776-6A849CA73DA6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenRastaDemo", "src\OpenRasta.Benchmarks\OpenRastaDemo\OpenRastaDemo.csproj", "{B262A705-C1B2-4C1A-AE34-3B15119F609E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenRastaDemo", "src\OpenRasta.Benchmarks\OpenRastaDemo\OpenRastaDemo.csproj", "{B262A705-C1B2-4C1A-AE34-3B15119F609E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenRastaDemo.Benchmark", "src\OpenRasta.Benchmarks\OpenRastaDemo.Benchmark\OpenRastaDemo.Benchmark.csproj", "{D5566579-4803-4CF6-AC60-25D7EC075F6C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenRastaDemo.Benchmark", "src\OpenRasta.Benchmarks\OpenRastaDemo.Benchmark\OpenRastaDemo.Benchmark.csproj", "{D5566579-4803-4CF6-AC60-25D7EC075F6C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenRastaDemo.Shared", "src\OpenRasta.Benchmarks\OpenRastaDemo.Shared\OpenRastaDemo.Shared.csproj", "{D0389498-4624-4D02-93C5-69F02E678273}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenRastaDemo.Shared", "src\OpenRasta.Benchmarks\OpenRastaDemo.Shared\OpenRastaDemo.Shared.csproj", "{D0389498-4624-4D02-93C5-69F02E678273}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestingKeepAlive.Web", "src\TestingKeepAlive.Web\TestingKeepAlive.Web.csproj", "{24B7B587-F7E7-4F56-BEA3-88F1A87C648C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestingKeepAlive.Console", "src\TestingKeepAlive.Console\TestingKeepAlive.Console.csproj", "{81426C52-CD04-4C22-85E7-F4FF4FB4E865}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -121,16 +125,24 @@ Global
 		{D0389498-4624-4D02-93C5-69F02E678273}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D0389498-4624-4D02-93C5-69F02E678273}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D0389498-4624-4D02-93C5-69F02E678273}.Release|Any CPU.Build.0 = Release|Any CPU
+		{24B7B587-F7E7-4F56-BEA3-88F1A87C648C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{24B7B587-F7E7-4F56-BEA3-88F1A87C648C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{24B7B587-F7E7-4F56-BEA3-88F1A87C648C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{24B7B587-F7E7-4F56-BEA3-88F1A87C648C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{81426C52-CD04-4C22-85E7-F4FF4FB4E865}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{81426C52-CD04-4C22-85E7-F4FF4FB4E865}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{81426C52-CD04-4C22-85E7-F4FF4FB4E865}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{81426C52-CD04-4C22-85E7-F4FF4FB4E865}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {E66BC41B-A020-4673-8A3F-1986A41479AD}
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{B262A705-C1B2-4C1A-AE34-3B15119F609E} = {F29C9EB9-4B9A-4D8D-A776-6A849CA73DA6}
 		{D5566579-4803-4CF6-AC60-25D7EC075F6C} = {F29C9EB9-4B9A-4D8D-A776-6A849CA73DA6}
 		{D0389498-4624-4D02-93C5-69F02E678273} = {F29C9EB9-4B9A-4D8D-A776-6A849CA73DA6}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E66BC41B-A020-4673-8A3F-1986A41479AD}
 	EndGlobalSection
 EndGlobal

--- a/src/TestingKeepAlive.Console/App.config
+++ b/src/TestingKeepAlive.Console/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+    </startup>
+</configuration>

--- a/src/TestingKeepAlive.Console/Program.cs
+++ b/src/TestingKeepAlive.Console/Program.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Text;
+using System.IO;
+using System.Net;
+using System.Threading;
+
+namespace TestingKeepAlive.Console
+{
+
+  class Program
+  {
+    static void Main(string[] args)
+    {
+      var address = new Uri("http://localhost:52995/");
+
+      var writer = TextWriter.Synchronized(System.Console.Out);
+
+      var posts = new Thread(() =>
+      {
+        var iteration = 0;
+        while (true)
+        {
+          try
+          {
+            var request = CreateRequest(address);
+            request.Method = "POST";
+            request.ContentType = "application/json";
+
+            using (var str = request.GetRequestStream())
+            {
+              var bytes = Encoding.UTF8.GetBytes(@"{ ""Data"": [1, 2, 3] }");
+              str.Write(bytes, 0, bytes.Length);
+            }
+
+            using (var response = (HttpWebResponse)request.GetResponse())
+            {
+              writer.WriteLine("{0} {1}", ++iteration, response.StatusCode);
+            }
+          }
+          catch (WebException webException)
+          {
+            var stream = webException.Response?.GetResponseStream();
+            if (stream != null)
+            {
+              using (var reader = new StreamReader(stream))
+              {
+                writer.WriteLine(reader.ReadToEnd());
+              }
+            }
+
+            throw;
+          }
+          catch (Exception exception)
+          {
+            writer.WriteLine(exception);
+            throw;
+          }
+
+          Thread.Sleep(10);
+        }
+      });
+
+      var gets = new Thread(() =>
+      {
+        var iteration = 0;
+        while (true)
+        {
+          try
+          {
+            var request = CreateRequest(address);
+            request.Method = "GET";
+
+            using (var response = (HttpWebResponse)request.GetResponse())
+            {
+              writer.WriteLine("{0} {1}", ++iteration, response.StatusCode);
+            }
+          }
+          catch (WebException webException)
+          {
+            var stream = webException.Response?.GetResponseStream();
+            if (stream != null)
+            {
+              using (var reader = new StreamReader(stream))
+              {
+                writer.WriteLine(reader.ReadToEnd());
+              }
+            }
+
+            throw;
+          }
+          catch (Exception exception)
+          {
+            writer.WriteLine(exception);
+            throw;
+          }
+
+          Thread.Sleep(10);
+        }
+
+      });
+
+      posts.Start();
+      gets.Start();
+
+      posts.Join();
+      gets.Join();
+    }
+
+    static HttpWebRequest CreateRequest(Uri uri)
+    {
+      var r = WebRequest.CreateHttp(uri);
+
+      // Uncomment either of the following lines and the issue goes away
+      //r.KeepAlive = false;
+      //r.ProtocolVersion = HttpVersion.Version10;
+
+      return r;
+    }
+  }
+}

--- a/src/TestingKeepAlive.Console/Properties/AssemblyInfo.cs
+++ b/src/TestingKeepAlive.Console/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("TestingKeepAlive.Console")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("TestingKeepAlive.Console")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("81426c52-cd04-4c22-85e7-f4ff4fb4e865")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/TestingKeepAlive.Console/TestingKeepAlive.Console.csproj
+++ b/src/TestingKeepAlive.Console/TestingKeepAlive.Console.csproj
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{81426C52-CD04-4C22-85E7-F4FF4FB4E865}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>TestingKeepAlive.Console</RootNamespace>
+    <AssemblyName>TestingKeepAlive.Console</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/TestingKeepAlive.Web/Config.cs
+++ b/src/TestingKeepAlive.Web/Config.cs
@@ -1,0 +1,47 @@
+﻿using System.Linq;
+using OpenRasta.Codecs.Newtonsoft.Json;
+using OpenRasta.Configuration;
+using OpenRasta.Hosting.Katana;
+using OpenRasta.Web;
+using Owin;
+
+namespace TestingKeepAlive.Web
+{
+  public class Config
+  {
+    public void Configuration(IAppBuilder app)
+    {
+      var openRastaConfiguration = new OpenRasta();
+
+      app.UseOpenRasta(openRastaConfiguration);
+    }
+
+    class OpenRasta : IConfigurationSource
+    {
+      public void Configure()
+      {
+        ResourceSpace.Has
+          .ResourcesOfType<Resource>()
+          .AtUri("/")
+          .HandledBy<Handler>()
+          .TranscodedBy<NewtonsoftJsonCodec>();
+      }
+    }
+
+    class Resource
+    {
+      public int[] Data { get; set; }
+    }
+
+    class Handler
+    {
+      public Resource Get() => new Resource
+      {
+        Data = Enumerable.Range(1, 10000).ToArray()
+      };
+
+      public OperationResult Post(Resource resource) => new OperationResult.NoContent();
+    }
+
+  }
+}

--- a/src/TestingKeepAlive.Web/Properties/AssemblyInfo.cs
+++ b/src/TestingKeepAlive.Web/Properties/AssemblyInfo.cs
@@ -1,0 +1,38 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+using Microsoft.Owin;
+using TestingKeepAlive.Web;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("TestingKeepAlive")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("TestingKeepAlive")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("24b7b587-f7e7-4f56-bea3-88f1a87c648c")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Revision and Build Numbers 
+// by using the '*' as shown below:
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: OwinStartup(typeof(Config))]

--- a/src/TestingKeepAlive.Web/TestingKeepAlive.Web.csproj
+++ b/src/TestingKeepAlive.Web/TestingKeepAlive.Web.csproj
@@ -1,0 +1,146 @@
+﻿<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.0\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.0\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{24B7B587-F7E7-4F56-BEA3-88F1A87C648C}</ProjectGuid>
+    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>TestingKeepAlive.Web</RootNamespace>
+    <AssemblyName>TestingKeepAlive.Web</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <UseIISExpress>true</UseIISExpress>
+    <Use64BitIISExpress />
+    <IISExpressSSLPort />
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
+    <UseGlobalApplicationHostFile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Owin, Version=4.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.4.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Host.SystemWeb, Version=4.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.Host.SystemWeb.4.0.1\lib\net45\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
+    </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Web.Services" />
+    <Reference Include="System.EnterpriseServices" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform">
+      <HintPath>..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Web.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Config.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="Web.Debug.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+    <None Include="Web.Release.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\OpenRasta.Codecs.Newtonsoft.Json\OpenRasta.Codecs.Newtonsoft.Json.csproj">
+      <Project>{1016D8C7-4F47-4335-8DF1-636EEBBF5A71}</Project>
+      <Name>OpenRasta.Codecs.Newtonsoft.Json</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\OpenRasta.Hosting.Katana\OpenRasta.Hosting.Katana.csproj">
+      <Project>{CE4A43AD-FCC6-4BC4-947C-635FEB91CA36}</Project>
+      <Name>OpenRasta.Hosting.Katana</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\OpenRasta\OpenRasta.csproj">
+      <Project>{3d251617-2581-4d9c-a639-5cfb0bb09420}</Project>
+      <Name>OpenRasta</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+        <WebProjectProperties>
+          <UseIIS>True</UseIIS>
+          <AutoAssignPort>True</AutoAssignPort>
+          <DevelopmentServerPort>52995</DevelopmentServerPort>
+          <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <IISUrl>http://localhost:52995/</IISUrl>
+          <NTLMAuthentication>False</NTLMAuthentication>
+          <UseCustomServer>False</UseCustomServer>
+          <CustomServerUrl>
+          </CustomServerUrl>
+          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+        </WebProjectProperties>
+      </FlavorProperties>
+    </VisualStudio>
+  </ProjectExtensions>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.0\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.0\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/TestingKeepAlive.Web/Web.Debug.config
+++ b/src/TestingKeepAlive.Web/Web.Debug.config
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit https://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/src/TestingKeepAlive.Web/Web.Release.config
+++ b/src/TestingKeepAlive.Web/Web.Release.config
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit https://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <compilation xdt:Transform="RemoveAttributes(debug)" />
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/src/TestingKeepAlive.Web/Web.config
+++ b/src/TestingKeepAlive.Web/Web.config
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  For more information on how to configure your ASP.NET application, please visit
+  https://go.microsoft.com/fwlink/?LinkId=169433
+  -->
+<configuration>
+  <system.web>
+    <compilation debug="true" targetFramework="4.6.1" />
+    <httpRuntime targetFramework="4.6.1" />
+  </system.web>
+  <system.codedom>
+    <compilers>
+      <compiler language="c#;cs;csharp" extension=".cs"
+                type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+                warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701" />
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb"
+                type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+                warningLevel="4"
+                compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
+    </compilers>
+  </system.codedom>
+
+</configuration>

--- a/src/TestingKeepAlive.Web/packages.config
+++ b/src/TestingKeepAlive.Web/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<packages>
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.0" targetFramework="net461" />
+  <package id="Microsoft.Owin" version="4.0.1" targetFramework="net461" />
+  <package id="Microsoft.Owin.Host.SystemWeb" version="4.0.1" targetFramework="net461" />
+  <package id="Owin" version="1.0" targetFramework="net461" />
+</packages>


### PR DESCRIPTION
I am hosting in IIS using owin.host.systemweb
I have a single client repeatedly GETing and POSTing some resources
I get the error "The server committed a protocol violation. Section=ResponseStatusLine" eventually

Here is a small test app to demonstrate it.  A WebApp which just hosts a single resource, and a Console app which continually GETs and POSTs to the the WebApp.  After running this, an error is shown very quickly


