### PR TITLE
RequestCodecSelector: treat null and empty Content-Length the same

### DIFF
--- a/src/OpenRasta/OperationModel/CodecSelectors/RequestCodecSelector.cs
+++ b/src/OpenRasta/OperationModel/CodecSelectors/RequestCodecSelector.cs
@@ -28,7 +28,7 @@ namespace OpenRasta.OperationModel.CodecSelectors
 
         public IEnumerable<IOperationAsync> Process(IEnumerable<IOperationAsync> operations)
         {
-            if (_request.Entity.ContentLength == 0)
+            if (_request.Entity.ContentLength.IsNullOr(0))
                 return LogSelected(operations.Where(operation => operation.Inputs.AllReady()));
 
             var requestMediaType = _request.Entity.ContentType ?? DetectMediaType();


### PR DESCRIPTION
This fixes #184, see that issue for some details about the behavior change I experienced here. I tracked this back to [a change made in this commit ](https://github.com/openrasta/openrasta-core/commit/e26ba3a3866dae25f311b3edf4e3e0435866839e#diff-93fcecd0bd6f0bbc1b03ae3c8f655d20L31), which removed the null handling in `RequestCodecSelector` to now allow that case to fall through into the rest of the logic. 

Looking at the commit message, though, it does sound like this was very intentional:

> Also removes the null check on content length when reading entities, to
support TE.

@serialseb Thoughts on the implications of putting this back in? Is there a better place to update?