### PR TITLE
Address DI issues in 2.6

### DIFF
--- a/src/OpenRasta/Configuration/MetaModel/MetaModelRepository.cs
+++ b/src/OpenRasta/Configuration/MetaModel/MetaModelRepository.cs
@@ -11,6 +11,11 @@ namespace OpenRasta.Configuration.MetaModel
   {
     readonly Func<IEnumerable<IMetaModelHandler>> _handlers;
 
+    public MetaModelRepository(IDependencyResolver resolver)
+      :this(resolver.ResolveAll<IMetaModelHandler>)
+    {
+    }
+
     public MetaModelRepository(Func<IEnumerable<IMetaModelHandler>> handlers)
     {
       _handlers = handlers;

--- a/src/OpenRasta/OperationModel/Interceptors/SystemAndAttributesOperationInterceptorProvider.cs
+++ b/src/OpenRasta/OperationModel/Interceptors/SystemAndAttributesOperationInterceptorProvider.cs
@@ -10,6 +10,11 @@ namespace OpenRasta.OperationModel.Interceptors
   {
     readonly Func<IEnumerable<IOperationInterceptor>> _systemInterceptors;
 
+    public SystemAndAttributesOperationInterceptorProvider(IDependencyResolver resolver)
+      : this(resolver.ResolveAll<IOperationInterceptor>)
+    {
+    }
+
     public SystemAndAttributesOperationInterceptorProvider(Func<IEnumerable<IOperationInterceptor>> systemInterceptors)
     {
       _systemInterceptors = systemInterceptors;

--- a/src/OpenRasta/Pipeline/Contributors/OperationFilterContributor.cs
+++ b/src/OpenRasta/Pipeline/Contributors/OperationFilterContributor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRasta.DI;
 using OpenRasta.OperationModel;
 using OpenRasta.Web;
 
@@ -9,6 +10,11 @@ namespace OpenRasta.Pipeline.Contributors
   public class OperationFilterContributor : KnownStages.IOperationFiltering
   {
     readonly Func<IEnumerable<IOperationFilter>> _createFilters;
+
+    public OperationFilterContributor(IDependencyResolver resolver)
+      : this(resolver.ResolveAll<IOperationFilter>)
+    {
+    }
 
     public OperationFilterContributor(Func<IEnumerable<IOperationFilter>> createFilters)
     {

--- a/src/OpenRasta/Pipeline/Contributors/RequestCodecSelector.cs
+++ b/src/OpenRasta/Pipeline/Contributors/RequestCodecSelector.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRasta.DI;
 using OpenRasta.OperationModel;
 using OpenRasta.Web;
 
@@ -10,6 +11,11 @@ namespace OpenRasta.Pipeline.Contributors
     : KnownStages.ICodecRequestSelection
   {
     readonly Func<IEnumerable<IOperationCodecSelector>> _codecSelectors;
+
+    public RequestCodecSelector(IDependencyResolver resolver)
+      : this(resolver.ResolveAll<IOperationCodecSelector>)
+    {
+    }
 
     public RequestCodecSelector(Func<IEnumerable<IOperationCodecSelector>> codecs)
     {

--- a/src/OpenRasta/Pipeline/Contributors/UriDecoratorsContributor.cs
+++ b/src/OpenRasta/Pipeline/Contributors/UriDecoratorsContributor.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRasta.DI;
 using OpenRasta.Web;
-using OpenRasta.Pipeline;
 using OpenRasta.Web.UriDecorators;
 
 namespace OpenRasta.Pipeline.Contributors
@@ -10,6 +10,11 @@ namespace OpenRasta.Pipeline.Contributors
   public class UriDecoratorsContributor : IPipelineContributor
   {
     readonly Func<IEnumerable<IUriDecorator>> _decorators;
+
+    public UriDecoratorsContributor(IDependencyResolver resolver)
+      : this(resolver.ResolveAll<IUriDecorator>)
+    {
+    }
 
     public UriDecoratorsContributor(Func<IEnumerable<IUriDecorator>> decorators)
     {


### PR DESCRIPTION
Opening this now as a placeholder as we continue to dig into the issues in 2.6 that seem to be related to resolving enumerable types, and a place to put notes. The issues still persists even with these changes as well.

Some example stacktraces:

```
Message: Could not resolve an enumerable for ExceptionInterceptor

OpenRasta.DI.Internal.EnumerableProfile`1.TryResolve(IDependencyRegistrationCollection registrations, ResolveContext resolveContext, Object& instance):92
OpenRasta.DI.Internal.FuncProfile`1+<>c__DisplayClass3_0.<ResolveTyped>b__0()
OpenRasta.OperationModel.MethodBased.MethodBasedOperationCreator+<>c__DisplayClass9_0.<CreateSyncDescriptor>b__0():42
OpenRasta.OperationModel.MethodBased.OperationDescriptor.Create():1
OpenRasta.OperationModel.MethodBased.MethodBasedOperationCreator+<>c.<CreateOperations>b__6_0(OperationDescriptor o)
System.Linq.Enumerable+WhereSelectEnumerableIterator`2.MoveNext():77
System.Linq.Buffer`1..ctor(IEnumerable`1 source):114
System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source):20
OpenRasta.OperationModel.MethodBased.MethodBasedOperationCreator.CreateOperations(IEnumerable`1 handlers):73
OpenRasta.Pipeline.Contributors.OperationCreatorContributor.CreateOperations(ICommunicationContext context):40
OpenRasta.Pipeline.CallGraph.ContributorBuilder+<>c__DisplayClass17_0.<OpenRasta.Pipeline.IPipeline.Notify>b__0(ICommunicationContext ctx)
OpenRasta.Pipeline.RequestMiddleware+<Invoke>d__2.MoveNext():472
```

```
Message: Could not resolve type OpenRasta.OperationModel.IOperationExecutor

OpenRasta.DI.Internal.FuncProfile`1+<>c__DisplayClass3_0.<ResolveTyped>b__0():58
OpenRasta.Pipeline.Contributors.OperationInvokerContributor+<ExecuteOperations>d__3.MoveNext():15
System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw():12
System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task):40
System.Runtime.CompilerServices.TaskAwaiter`1.GetResult():11
OpenRasta.Pipeline.RequestMiddleware+<Invoke>d__2.MoveNext():568
```