### PR TITLE
improve perf of querysegments function

### DIFF
--- a/src/OpenRasta/UriTemplate.cs
+++ b/src/OpenRasta/UriTemplate.cs
@@ -119,9 +119,15 @@ namespace OpenRasta
 
     static Dictionary<string, QuerySegment> ParseQueryStringSegments(IEnumerable<QuerySegment> queryString)
     {
-      return queryString
-        .GroupBy(qs => qs.Key, StringComparer.OrdinalIgnoreCase)
-        .ToDictionary(qs => qs.Key, qs => qs.First(), StringComparer.OrdinalIgnoreCase);
+      var result = new Dictionary<string, QuerySegment>(StringComparer.OrdinalIgnoreCase);
+      foreach (var qs in queryString)
+      {
+        if (!result.ContainsKey(qs.Key))
+        {
+          result.Add(qs.Key, qs);
+        }
+      }
+      return result;
     }
 
     public static IEnumerable<QuerySegment> ParseQueryStringSegments(string query)
@@ -228,8 +234,8 @@ namespace OpenRasta
         else if (segment.Type == SegmentType.Variable)
         {
           var value = parameters[segment.Text.ToUpperInvariant()];
-          
-          
+
+
           path.Append(value.Replace("/", "%2F")
             .Replace("?", "%3F")
             .Replace("#", "%23"));
@@ -247,7 +253,7 @@ namespace OpenRasta
           var qsValue = parameters[querySegment.Value.Value]
             .Replace("&", "%25")
             .Replace("#", "%23");
-          
+
           path.Append(querySegment.Value.Key).Append("=")
             .Append(qsValue).Append("&");
         }


### PR DESCRIPTION
First in a series of performance tweaks from Olo that affect the match function, which is hit in every request. This change eliminates the use of the  GroupBy().ToDictionary() pattern by building the dictionary by hand which saves some time and allocation.

 - [x] the code
 - [ ] If it's a non-trivial piece of code, signing a CLA
 - [ ] If it breaks, change, fix or add to existing behaviour, updating
       CHANGELOG.md
 - [ ] If it's a bug fix, tests in the Tests `project`, or scenarios in the `TestRig`.
 - [ ] On top of HEAD, unless it's a bugfix on a previous version
 - [ ] VERSION file updated if not creating a pull-request on top of `master`

If those are needed, and you haven't and can't, we thank you enormously for your
contribution, and we'll add those before merging the pull request.

Thanks!

The OpenRasta community
