### PR TITLE
hoist repeated work out of the loop in the match functions

### DIFF
--- a/src/OpenRasta/UriTemplate.cs
+++ b/src/OpenRasta/UriTemplate.cs
@@ -346,8 +346,7 @@ namespace OpenRasta
       if (baseLeft != uri.GetLeftPart(UriPartial.Authority))
         return null;
 
-      var segments = uri.Segments;
-      var candidateSegments = baseSegments.ToList();
+      var candidateSegments = uri.Segments.Select(RemoveTrailingSlash).ToList();
       foreach (var baseUriSegment in baseSegments)
         if (baseUriSegment == candidateSegments[0])
           candidateSegments.RemoveAt(0);
@@ -362,19 +361,25 @@ namespace OpenRasta
       for (var i = 0; i < _segments.Count; i++)
       {
         var segment = candidateSegments[i];
-        var unescapedText = Uri.UnescapeDataString(segment);
 
-        candidateSegments[i] = segment;
+        var candidateSegment = new
+        {
+          Text = segment,
+          UnescapedText = Uri.UnescapeDataString(segment),
+          ProposedSegment = _segments[i]
+        };
 
-        switch (_segments[i].Type)
+        candidateSegments[i] = candidateSegment.Text;
+
+        switch (candidateSegment.ProposedSegment.Type)
         {
           case SegmentType.Literal when
-            string.CompareOrdinal(_segments[i].Text, unescapedText) != 0:
+            string.CompareOrdinal(candidateSegment.ProposedSegment.Text, candidateSegment.UnescapedText) != 0:
             return null;
           case SegmentType.Wildcard:
             throw new NotImplementedException("Not finished wildcards implementation yet");
           case SegmentType.Variable:
-            boundVariables.Add(_segments[i].Text, Uri.UnescapeDataString(segment));
+            boundVariables.Add(candidateSegment.ProposedSegment.Text, Uri.UnescapeDataString(candidateSegment.Text));
             break;
         }
       }


### PR DESCRIPTION
2nd perf tweak to the match function from Olo:
This hoists a loop invariant out of the inner loop of the match functions. This has a  large impact on time and allocations. 


You don't have to do all of those following things, they are what we try and get 
done for code coming in:

 - [x] the code
 - [ ] If it's a non-trivial piece of code, signing a CLA
 - [ ] If it breaks, change, fix or add to existing behaviour, updating
       CHANGELOG.md
 - [ ] If it's a bug fix, tests in the Tests `project`, or scenarios in the `TestRig`.
 - [ ] On top of HEAD, unless it's a bugfix on a previous version
 - [ ] VERSION file updated if not creating a pull-request on top of `master`

If those are needed, and you haven't and can't, we thank you enormously for your
contribution, and we'll add those before merging the pull request.

Thanks!

The OpenRasta community
