### PR TITLE
Update UriTemplate.Match to compare case-insensitively. 

### DIFF
--- a/src/OpenRasta.Tests.Unit/UriTemplate_Specification.cs
+++ b/src/OpenRasta.Tests.Unit/UriTemplate_Specification.cs
@@ -149,6 +149,13 @@ namespace UriTemplate_Specification
     }
 
     [Test]
+    public void matching_urls_with_different_casing_returns_match()
+    {
+      GivenAMatching("/weather", "http://localhost/Weather");
+      ThenTheMatch.BaseUri.ShouldBe(BaseUris.First());
+    }
+
+    [Test]
     public void the_base_uri_is_the_one_provided_in_the_match()
     {
       GivenAMatching("/weather/{state}/{city}", "http://localhost/weather/Washington/Seattle");

--- a/src/OpenRasta/UriTemplate.cs
+++ b/src/OpenRasta/UriTemplate.cs
@@ -371,7 +371,8 @@ namespace OpenRasta
         switch (candidateSegment.ProposedSegment.Type)
         {
           case SegmentType.Literal when
-            !string.Equals(candidateSegment.ProposedSegment.Text, candidateSegment.UnescapedText, StringComparison.OrdinalIgnoreCase):
+            string.Equals(candidateSegment.ProposedSegment.Text, candidateSegment.UnescapedText, StringComparison.OrdinalIgnoreCase) == false:
+
             return null;
           case SegmentType.Wildcard:
             throw new NotImplementedException("Not finished wildcards implementation yet");

--- a/src/OpenRasta/UriTemplate.cs
+++ b/src/OpenRasta/UriTemplate.cs
@@ -371,7 +371,7 @@ namespace OpenRasta
         switch (candidateSegment.ProposedSegment.Type)
         {
           case SegmentType.Literal when
-            string.CompareOrdinal(candidateSegment.ProposedSegment.Text, candidateSegment.UnescapedText) != 0:
+            !string.Equals(candidateSegment.ProposedSegment.Text, candidateSegment.UnescapedText, StringComparison.OrdinalIgnoreCase):
             return null;
           case SegmentType.Wildcard:
             throw new NotImplementedException("Not finished wildcards implementation yet");


### PR DESCRIPTION
It appears that UriTemplate.Match was changed to be case-sensitive in [this](https://github.com/openrasta/openrasta-core/commit/33e3c3957db347e59495d20bfe1f7601e22e3919) commit, and it doesn't look like it was intentional.  

Without this change if the route `/healthcheck` is registered, `/healthCheck` will return a 404. 

Hi there!

Thank you so much for contributing this pull request. We love when the community
steps up and share, and we're enormously thankful.

You don't have to do all of those following things, they are what we try and get 
done for code coming in:

 - [x] the code
 - [ ] If it's a non-trivial piece of code, signing a CLA
 - [ ] If it breaks, change, fix or add to existing behaviour, updating
       CHANGELOG.md
 - [x] If it's a bug fix, tests in the Tests `project`, or scenarios in the `TestRig`.
 - [x] On top of HEAD, unless it's a bugfix on a previous version
 - [ ] VERSION file updated if not creating a pull-request on top of `master`

If those are needed, and you haven't and can't, we thank you enormously for your
contribution, and we'll add those before merging the pull request.

Thanks!

The OpenRasta community
