### PR TITLE
refactor Invoke to return just an object

### DIFF
--- a/src/OpenRasta/Binding/DefaultObjectBinderLocator.cs
+++ b/src/OpenRasta/Binding/DefaultObjectBinderLocator.cs
@@ -38,7 +38,7 @@ namespace OpenRasta.Binding
             {
                 try
                 {
-                    return binderMethod.Invoke(null, TypeSystem, member).OfType<IObjectBinder>().Single();
+                    return (IObjectBinder)binderMethod.Invoke(null, TypeSystem, member);
                 }
                 catch (Exception e)
                 {

--- a/src/OpenRasta/OperationModel/MethodBased/AsyncMethod.cs
+++ b/src/OpenRasta/OperationModel/MethodBased/AsyncMethod.cs
@@ -21,7 +21,7 @@ namespace OpenRasta.OperationModel.MethodBased
       var instance = CreateInstance(OwnerType, Resolver);
       var parameters = GetParameters();
 
-      return ((Task) Method.Invoke(instance, parameters).Single())
+      return ((Task) Method.Invoke(instance, parameters))
         .ContinueWith(task => Enumerable.Empty<OutputMember>());
     }
   }
@@ -40,7 +40,7 @@ namespace OpenRasta.OperationModel.MethodBased
       var instance = CreateInstance(OwnerType, Resolver);
       var parameters = GetParameters();
 
-      var result = await (Task<T>) Method.Invoke(instance, parameters).Single();
+      var result = await (Task<T>) Method.Invoke(instance, parameters);
       return new[]
       {
         new OutputMember

--- a/src/OpenRasta/OperationModel/MethodBased/SyncMethod.cs
+++ b/src/OpenRasta/OperationModel/MethodBased/SyncMethod.cs
@@ -28,7 +28,7 @@ namespace OpenRasta.OperationModel.MethodBased
         new OutputMember
         {
           Member = Method.OutputMembers.Single(),
-          Value = Method.Invoke(instance, parameters).First()
+          Value = Method.Invoke(instance, parameters)
         }
       };
     }

--- a/src/OpenRasta/TypeSystem/IMethod.cs
+++ b/src/OpenRasta/TypeSystem/IMethod.cs
@@ -32,7 +32,7 @@ namespace OpenRasta.TypeSystem
     /// </summary>
     /// <param name="target">The target instance on which to call the method.</param>
     /// <param name="parameters">The parameters passed to the method when being invoked.</param>
-    /// <returns>A list of objects returned by the method.</returns>
-    IEnumerable<object> Invoke(object target, params object[] parameters);
+    /// <returns>the object returned by the method.</returns>
+    object Invoke(object target, params object[] parameters);
   }
 }

--- a/src/OpenRasta/TypeSystem/ReflectionBased/ReflectionBasedMethod.cs
+++ b/src/OpenRasta/TypeSystem/ReflectionBased/ReflectionBasedMethod.cs
@@ -47,9 +47,9 @@ namespace OpenRasta.TypeSystem.ReflectionBased
             return _methodInfo.GetCustomAttributes(typeof(T), true).Cast<T>();
         }
 
-        public IEnumerable<object> Invoke(object target, params object[] members)
+        public object Invoke(object target, params object[] members)
         {
-            return new[]{ _methodInfo.Invoke(target, members) };
+            return _methodInfo.Invoke(target, members);
         }
 
         void EnsureInputMembersExist()


### PR DESCRIPTION
This refactors `ReflectionBasedMethod.Invoke` to just return an object. This eliminates the allocation of an array to store just one object, and removes the need for all consumers to call `Single()` or `First()` on the result.

This is a microsecond-ish benefit, but also makes the code a bit simpler, unless I am missing something.


 - [x] the code
 - [ ] If it's a non-trivial piece of code, signing a CLA
 - [ ] If it breaks, change, fix or add to existing behaviour, updating
       CHANGELOG.md
 - [ ] If it's a bug fix, tests in the Tests `project`, or scenarios in the `TestRig`.
 - [ ] On top of HEAD, unless it's a bugfix on a previous version
 - [ ] VERSION file updated if not creating a pull-request on top of `master`

If those are needed, and you haven't and can't, we thank you enormously for your
contribution, and we'll add those before merging the pull request.

Thanks!

The OpenRasta community
