### PR TITLE
benchmarks multitarget and command line

### DIFF
--- a/src/OpenRasta.Benchmarks/OpenRastaDemo.Benchmark/EndToEnd/EndToEndHealthCheck.cs
+++ b/src/OpenRasta.Benchmarks/OpenRastaDemo.Benchmark/EndToEnd/EndToEndHealthCheck.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -9,13 +8,12 @@ using OpenRasta.Hosting.InMemory;
 using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using OpenRasta.Concordia;
 using OpenRasta.DI;
 using OpenRasta.DI.Windsor;
 using OpenRasta.Hosting.AspNetCore;
 using OpenRasta.IO;
-
+using BenchmarkDotNet.Jobs;
 
 namespace OpenRastaDemo.Benchmark.EndToEnd
 {
@@ -42,7 +40,9 @@ namespace OpenRastaDemo.Benchmark.EndToEnd
     public IDependencyResolver Resolver { get; } = new WindsorDependencyResolver();
   }
 
-  [HtmlExporter, InProcess, MemoryDiagnoser]
+  [SimpleJob(RuntimeMoniker.Net48)]
+  [SimpleJob(RuntimeMoniker.NetCoreApp21)]
+  [HtmlExporter,MemoryDiagnoser]
   public class SimpleHealthCheckBenchmark
   {
     InMemoryHost _memServer;

--- a/src/OpenRasta.Benchmarks/OpenRastaDemo.Benchmark/OpenRastaDemo.Benchmark.csproj
+++ b/src/OpenRasta.Benchmarks/OpenRastaDemo.Benchmark/OpenRastaDemo.Benchmark.csproj
@@ -2,14 +2,15 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
-        <LangVersion>latest</LangVersion>
+        <TargetFrameworks>netcoreapp2.1;net48</TargetFrameworks>
+        <LangVersion>8</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-      <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
-      <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
+      <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
+      <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
+      <PackageReference Include="System.Net.Http" Version="4.3.4" />
       <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
     </ItemGroup>
 

--- a/src/OpenRasta.Benchmarks/OpenRastaDemo.Benchmark/Program.cs
+++ b/src/OpenRasta.Benchmarks/OpenRastaDemo.Benchmark/Program.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using BenchmarkDotNet.Running;
-using OpenRasta.Collections;
-using OpenRastaDemo.Benchmark.Uris;
 
 namespace OpenRastaDemo.Benchmark
 {
@@ -10,20 +7,20 @@ namespace OpenRastaDemo.Benchmark
   {
     static async Task Main(string[] args)
     {
-//#if DEBUG
-////      var benchMark = new JsonBenchmark();
-////      benchMark.Setup();
-////      var response = await benchMark.GetMeSomeLittleJson();
-////      var content = await response.Content.ReadAsStringAsync();
-//      var benchMark = new ReverseProxyBenchmark();
-//      benchMark.Setup();
-//      var response = await benchMark.GetMeSomeProxy();
-//      var content = await response.Content.ReadAsStringAsync();
-//      Console.WriteLine(content);
-//
-//#else
+      //#if DEBUG
+      ////      var benchMark = new JsonBenchmark();
+      ////      benchMark.Setup();
+      ////      var response = await benchMark.GetMeSomeLittleJson();
+      ////      var content = await response.Content.ReadAsStringAsync();
+      //      var benchMark = new ReverseProxyBenchmark();
+      //      benchMark.Setup();
+      //      var response = await benchMark.GetMeSomeProxy();
+      //      var content = await response.Content.ReadAsStringAsync();
+      //      Console.WriteLine(content);
+      //
+      //#else
 
-     BenchmarkRunner.Run<EndToEnd.SimpleHealthCheckBenchmark>();
+      BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
 //      new BenchmarkSwitcher(typeof(Program).Assembly).RunAll();
 //#endif
     }

--- a/src/OpenRasta.Benchmarks/OpenRastaDemo.Benchmark/ReverseProxyBenchmark.cs
+++ b/src/OpenRasta.Benchmarks/OpenRastaDemo.Benchmark/ReverseProxyBenchmark.cs
@@ -1,6 +1,7 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,7 +10,8 @@ using OpenRastaDemo.Shared;
 
 namespace OpenRastaDemo.Benchmark
 {
-  [CoreJob]
+  [SimpleJob(RuntimeMoniker.Net48)]
+  [SimpleJob(RuntimeMoniker.NetCoreApp21)]
   public class ReverseProxyBenchmark
   {
     HttpClient client;
@@ -19,7 +21,7 @@ namespace OpenRastaDemo.Benchmark
     public void Setup()
     {
       var configurationSource = new DemoConfigurationSource(1);
-      
+
       server = new TestServer(new WebHostBuilder()
         .ConfigureServices(s => s.AddSingleton<IConfigurationSource>(configurationSource))
         .UseStartup<Startup>()

--- a/src/OpenRasta.Benchmarks/OpenRastaDemo.Benchmark/SerializationBenchmark.cs
+++ b/src/OpenRasta.Benchmarks/OpenRastaDemo.Benchmark/SerializationBenchmark.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.IO;
-using System.Net.Http;
+﻿using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
@@ -9,21 +7,21 @@ using BenchmarkDotNet.Validators;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
-using Newtonsoft.Json;
 using OpenRasta.Configuration;
-using OpenRasta.Web.Markup.Modules;
 using OpenRastaDemo.Shared;
 
 namespace OpenRastaDemo.Benchmark
 {
-  [CoreJob(), MemoryDiagnoser,HtmlExporter(),GcServer(),ReturnValueValidator(true)]
+  [SimpleJob(RuntimeMoniker.Net48)]
+  [SimpleJob(RuntimeMoniker.NetCoreApp21)]
+  [MemoryDiagnoser,HtmlExporter(),GcServer(),ReturnValueValidator(true)]
   public class SerializationBenchmark
   {
     HttpClient client;
     TestServer server;
 
     [Params(50000)] public int Items;
-    
+
     [GlobalSetup]
     public void Setup()
     {

--- a/src/OpenRasta.Benchmarks/OpenRastaDemo.Benchmark/UriTemplates/Benchmark.cs
+++ b/src/OpenRasta.Benchmarks/OpenRastaDemo.Benchmark/UriTemplates/Benchmark.cs
@@ -1,13 +1,15 @@
 using System;
-using System.Diagnostics;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
 using OpenRasta.Configuration.MetaModel;
 using OpenRasta.DI;
 using OpenRasta.Hosting.InMemory;
 using OpenRasta.Web;
 namespace OpenRastaDemo.Benchmark.UriTemplates
 {
-  [HtmlExporter, InProcess, MemoryDiagnoser]
+  [SimpleJob(RuntimeMoniker.Net48)]
+  [SimpleJob(RuntimeMoniker.NetCoreApp21)]
+  [HtmlExporter,MemoryDiagnoser]
   public class Benchmark
   {
     IMetaModelRepository repository;

--- a/src/OpenRasta.Benchmarks/OpenRastaDemo.Benchmark/Uris/MatchingLiterals.cs
+++ b/src/OpenRasta.Benchmarks/OpenRastaDemo.Benchmark/Uris/MatchingLiterals.cs
@@ -1,11 +1,13 @@
 using System;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
 using OpenRasta.Web;
-using Xunit;
 
 namespace OpenRastaDemo.Benchmark.Uris
 {
-  [HtmlExporter, InProcess, MemoryDiagnoser]
+  [SimpleJob(RuntimeMoniker.Net48)]
+  [SimpleJob(RuntimeMoniker.NetCoreApp21)]
+  [HtmlExporter,MemoryDiagnoser]
   public class Matching
   {
     TemplatedUriResolver _templatedUriResolver;
@@ -16,7 +18,7 @@ namespace OpenRastaDemo.Benchmark.Uris
       {
         new UriRegistration("/events/", new object()),
         new UriRegistration("/events/{id}", new object()),
-        new UriRegistration("/events/?by={by}", new object())        
+        new UriRegistration("/events/?by={by}", new object())
       };
     }
 

--- a/src/OpenRasta.Benchmarks/OpenRastaDemo.Shared/OpenRastaDemo.Shared.csproj
+++ b/src/OpenRasta.Benchmarks/OpenRastaDemo.Shared/OpenRastaDemo.Shared.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp2.1;net48</TargetFrameworks>
     </PropertyGroup>
-    
+
     <ItemGroup>
       <ProjectReference Include="..\..\OpenRasta.Codecs.Newtonsoft.Json\OpenRasta.Codecs.Newtonsoft.Json.csproj" />
       <ProjectReference Include="..\..\OpenRasta.Hosting.AspNetCore\OpenRasta.Hosting.AspNetCore.csproj" />
       <ProjectReference Include="..\..\OpenRasta.Plugins.Hydra\OpenRasta.Plugins.Hydra.csproj" />
       <ProjectReference Include="..\..\OpenRasta.Plugins.ReverseProxy\OpenRasta.Plugins.ReverseProxy.csproj" />
     </ItemGroup>
-    
+
 </Project>

--- a/src/OpenRasta.Benchmarks/OpenRastaDemo/OpenRastaDemo.csproj
+++ b/src/OpenRasta.Benchmarks/OpenRastaDemo/OpenRastaDemo.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp2.1;net48</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This sets up the benchmark project to be runnable from the command line with options and filters to select which benchmark you want to run, see:
https://benchmarkdotnet.org/articles/guides/console-args.html

if you provide no options, you will be prompted at the command line for which benchmark(s) you want to run.

This also sets up the benchmark project to run the tests against multiple runtimes, currently net48 and netcoreapp21, though we can expand that as we see fit.




 - [x] the code
 - [ ] If it's a non-trivial piece of code, signing a CLA
 - [ ] If it breaks, change, fix or add to existing behaviour, updating
       CHANGELOG.md
 - [ ] If it's a bug fix, tests in the Tests `project`, or scenarios in the `TestRig`.
 - [ ] On top of HEAD, unless it's a bugfix on a previous version
 - [ ] VERSION file updated if not creating a pull-request on top of `master`

If those are needed, and you haven't and can't, we thank you enormously for your
contribution, and we'll add those before merging the pull request.

Thanks!

The OpenRasta community
