### PR TITLE
added tests and fix for missing InMemoryHost headers

### DIFF
--- a/src/OpenRasta/Hosting/InMemory/InMemoryHost.cs
+++ b/src/OpenRasta/Hosting/InMemory/InMemoryHost.cs
@@ -101,6 +101,9 @@ namespace OpenRasta.Hosting.InMemory
         }
       }
 
+      // lowercase r ensures the use of RFC 822 formatting
+      context.Response.Headers.Add("Date", DateTime.Now.ToString("r"));
+
       if (context.Response.Entity?.Stream.CanSeek == true)
         context.Response.Entity.Stream.Position = 0;
       return context.Response;

--- a/src/OpenRasta/Hosting/InMemory/InMemoryRequest.cs
+++ b/src/OpenRasta/Hosting/InMemory/InMemoryRequest.cs
@@ -21,6 +21,7 @@ namespace OpenRasta.Hosting.InMemory
         public InMemoryRequest()
         {
             Headers = new HttpHeaderDictionary();
+            Headers.Add("Host", "http://localhost/");
             Entity = new HttpEntity(Headers, new MemoryStream());
             CodecParameters = new List<string>();
         }

--- a/src/Tests/Hosting.InMemory/in_memory_request_headers.cs
+++ b/src/Tests/Hosting.InMemory/in_memory_request_headers.cs
@@ -1,0 +1,22 @@
+﻿using OpenRasta.Hosting.InMemory;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Hosting.InMemory
+{
+  public class in_memory_request_headers
+  {
+    InMemoryRequest _request;
+
+    public in_memory_request_headers()
+    {
+      _request = new InMemoryRequest();
+    }
+
+    [Fact]
+    public void contains_host_header()
+    {
+      _request.Headers.ContainsKey("Host").ShouldBeTrue();
+    }
+  }
+}

--- a/src/Tests/Hosting.InMemory/in_memory_response_headers.cs
+++ b/src/Tests/Hosting.InMemory/in_memory_response_headers.cs
@@ -1,0 +1,26 @@
+﻿using OpenRasta.Hosting.InMemory;
+using OpenRasta.Web;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Hosting.InMemory
+{
+  public class in_memory_response_headers
+  {
+    IResponse _response;
+    InMemoryHost _host;
+
+    public in_memory_response_headers()
+    {
+      _host = new InMemoryHost();
+    }
+
+    [Fact]
+    public async void contains_date_header()
+    {
+      _response = await _host.ProcessRequestAsync(new InMemoryRequest());
+
+      _response.Headers.ContainsKey("Date").ShouldBeTrue();
+    }
+  }
+}

--- a/src/Tests/Plugins.Diagnostics/trace_method.cs
+++ b/src/Tests/Plugins.Diagnostics/trace_method.cs
@@ -39,6 +39,7 @@ namespace Tests.Scenarios.HandlerSelection.Plugins.Diagnostics
         using (var reader = new StreamReader(response.Entity.Stream, Encoding.UTF8))
           reader.ReadToEnd().ShouldBe(
             "TRACE /1 HTTP/1.1\r\n" +
+            "Host: http://localhost/\r\n" +
             "Accept: */*\r\n" +
             "User-Agent: stuff\r\n\r\n");
       }


### PR DESCRIPTION
You don't have to do all of those following things, they are what we try and get 
done for code coming in:

 - [x] the code
 - [ ] If it's a non-trivial piece of code, signing a CLA
 - [ ] If it breaks, change, fix or add to existing behaviour, updating
       CHANGELOG.md
 - [x] If it's a bug fix, tests in the Tests `project`, or scenarios in the `TestRig`.
 - [ ] On top of HEAD, unless it's a bugfix on a previous version
 - [ ] VERSION file updated if not creating a pull-request on top of `master`

My Changes
- 

Added unit tests and updates to classes intended to fix #21 

- [x] Add `in_memory_response_headers` and `in_memory_resquest_headers` classes under `Tests.Hosting.InMemory` to ensure that the headers appear
- [x] Edit `InMemoryHost` to add the current time in RFC 822 format to the `InMemoryResponse` Date header after processing
- [x] Edit `InMemoryRequest` to include the Host header upon creation, set to `http://localhost/`
